### PR TITLE
fix: compatibility with DSH 0.1.0-rc.6 harness

### DIFF
--- a/lib/runtime-install.js
+++ b/lib/runtime-install.js
@@ -410,7 +410,8 @@ async function prepareManaged(ctx, config, manifest) {
             try {
                 const uv = await runCollected(ctx, ['uv', '--version'], stateRoot, { env: installEnv });
                 if (uv.exitCode === 0 && !uv.timedOut) {
-                    const create = await runCollected(ctx, ['uv', 'venv', '--python', bootstrap.command.program, staging], stateRoot, { timeoutMs: PREPARE_TIMEOUT_MS, env: installEnv });
+                    const interpreter = await ctx.subprocess.resolveExecutable(bootstrap.command.program, installEnv);
+                    const create = await runCollected(ctx, ['uv', 'venv', '--python', interpreter, staging], stateRoot, { timeoutMs: PREPARE_TIMEOUT_MS, env: installEnv });
                     if (create.exitCode !== 0 || create.timedOut) {
                         throw new VisionToolkitError('runtime', `uv failed to create the managed runtime: ${create.stderr.trim()}`);
                     }

--- a/lib/types/web.d.ts
+++ b/lib/types/web.d.ts
@@ -64,7 +64,7 @@ export declare class VisionToolkitWebBackend {
     handle(req: IncomingMessage, res: ServerResponse): Promise<void>;
 }
 /**
- * Attach optional Web routes whenever an httpServer service is present.
+ * Attach optional Web routes whenever an webServer service is present.
  * @param ctx - plugin context owning route effects.
  * @param backend - Settings handler.
  * @param artifacts - signed Artifact handler.

--- a/lib/web.js
+++ b/lib/web.js
@@ -224,21 +224,21 @@ export class VisionToolkitWebBackend {
     }
 }
 /**
- * Attach optional Web routes whenever an httpServer service is present.
+ * Attach optional Web routes whenever an webServer service is present.
  * @param ctx - plugin context owning route effects.
  * @param backend - Settings handler.
  * @param artifacts - signed Artifact handler.
  */
 export function installVisionToolkitWeb(ctx, backend, artifacts) {
-    ctx.inject(['httpServer'], (webCtx) => {
+    ctx.inject(['webServer'], (webCtx) => {
         webCtx.effect(() => {
             const detach = artifacts.attachRoute();
-            const disposeArtifact = webCtx.httpServer.register({
+            const disposeArtifact = webCtx.webServer.register({
                 kind: 'prefix',
                 path: ARTIFACT_ROUTE_PREFIX,
                 handler: (req, res) => artifacts.handle(req, res),
             });
-            const disposeSettings = webCtx.httpServer.register({
+            const disposeSettings = webCtx.webServer.register({
                 kind: 'exact',
                 path: SETTINGS_ROUTE,
                 handler: (req, res) => backend.handle(req, res),

--- a/src/runtime-install.ts
+++ b/src/runtime-install.ts
@@ -509,9 +509,10 @@ async function prepareManaged(
       try {
         const uv = await runCollected(ctx, ['uv', '--version'], stateRoot, { env: installEnv })
         if (uv.exitCode === 0 && !uv.timedOut) {
+          const interpreter = await ctx.subprocess.resolveExecutable(bootstrap.command.program, installEnv)
           const create = await runCollected(
             ctx,
-            ['uv', 'venv', '--python', bootstrap.command.program, staging],
+            ['uv', 'venv', '--python', interpreter, staging],
             stateRoot,
             { timeoutMs: PREPARE_TIMEOUT_MS, env: installEnv },
           )

--- a/src/web.ts
+++ b/src/web.ts
@@ -10,7 +10,7 @@ import type { Context } from 'cordis'
 import type { CredentialInfo } from '@deepseek-ai/dsh-credentials'
 import { credentialRef } from '@deepseek-ai/dsh-credentials'
 import { SettingsConflictError, type SettingsDescriptor } from '@deepseek-ai/dsh-settings'
-// Type-only import activates the optional httpServer Context declaration.
+// Type-only import activates the optional webServer Context declaration.
 import type {} from '@deepseek-ai/dsh-host-webserver'
 import { ArtifactAccessController, ARTIFACT_ROUTE_PREFIX } from './artifact-access.ts'
 import {
@@ -302,7 +302,7 @@ export class VisionToolkitWebBackend {
 }
 
 /**
- * Attach optional Web routes whenever an httpServer service is present.
+ * Attach optional Web routes whenever an webServer service is present.
  * @param ctx - plugin context owning route effects.
  * @param backend - Settings handler.
  * @param artifacts - signed Artifact handler.
@@ -312,15 +312,15 @@ export function installVisionToolkitWeb(
   backend: VisionToolkitWebBackend,
   artifacts: ArtifactAccessController,
 ): void {
-  ctx.inject(['httpServer'], (webCtx) => {
+  ctx.inject(['webServer'], (webCtx) => {
     webCtx.effect(() => {
       const detach = artifacts.attachRoute()
-      const disposeArtifact = webCtx.httpServer.register({
+      const disposeArtifact = webCtx.webServer.register({
         kind: 'prefix',
         path: ARTIFACT_ROUTE_PREFIX,
         handler: (req, res) => artifacts.handle(req, res),
       })
-      const disposeSettings = webCtx.httpServer.register({
+      const disposeSettings = webCtx.webServer.register({
         kind: 'exact',
         path: SETTINGS_ROUTE,
         handler: (req, res) => backend.handle(req, res),


### PR DESCRIPTION
## Summary

Compatibility fixes for the current DeepSeek Harness (`0.1.0-rc.6`). Two issues prevented the plugin from working on the current harness:

### 1. Rename injected web service `httpServer` → `webServer`

The DSH harness renamed its browser HTTP carrier service from `httpServer` to `webServer`. The plugin was injecting the old name, so the Settings route (`/_dsh/vision-toolkit/settings`) and the signed artifact routes were never registered. The browser Settings page then fetched a route that fell through to the SPA fallback and failed with:

```
Unexpected token '<', "<!doctype "... is not valid JSON
```

Changes:
- `src/web.ts` / `lib/web.js`: `ctx.inject(['webServer'])` and `webCtx.webServer.register(...)`
- `lib/types/web.d.ts`: doc comment

### 2. Resolve an absolute interpreter path for `uv venv --python`

`resolveBootstrapPython` may return a bare executable name (`python`). When the runtime cache directory contains a `python/` subdirectory, `uv venv --python python` treats `python` as a relative directory and fails with:

```
error: No interpreter found in directory `python`
```

The interpreter is now resolved to an absolute path via `ctx.subprocess.resolveExecutable()` before being passed to uv.

Changes:
- `src/runtime-install.ts` / `lib/runtime-install.js`

## Test plan

Both fixes were verified against DSH `0.1.0-rc.6` on Windows:
- The Settings page loads and the Settings route returns JSON.
- The managed Python runtime prepares successfully with uv.
