### PR TITLE
docs: point public project links to Anionex

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: mailto:davidyang042@gmail.com?subject=dsh-vision-toolkit%20security%20report
     about: Report suspected vulnerabilities privately; do not include credentials or private image data in a public issue.
   - name: Support guide
-    url: https://github.com/dsh-external/dsh-vision-toolkit/blob/main/SUPPORT.md
+    url: https://github.com/Anionex/dsh-vision-toolkit/blob/main/SUPPORT.md
     about: Choose the right channel and collect the required environment details before opening an issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 - Runtime teardown cancels in-flight operations before removing Agent-scoped tools, the activation bootstrap, and the Skill.
 - The Web client is published through the current nested `dsh.client` manifest and loader-compatible built artifact required by DSH snapshot0810.
 
-[Unreleased]: https://github.com/dsh-external/dsh-vision-toolkit/compare/v0.1.2...HEAD
-[0.1.2]: https://github.com/dsh-external/dsh-vision-toolkit/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/dsh-external/dsh-vision-toolkit/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/dsh-external/dsh-vision-toolkit/releases/tag/v0.1.0
+[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/3bc82526e63e559ee874ca436dace2ec475c35c2...HEAD
+[0.1.2]: https://github.com/Anionex/dsh-vision-toolkit/compare/64932217cf0194c50ee78dfc580e886ef2355300...3bc82526e63e559ee874ca436dace2ec475c35c2
+[0.1.1]: https://github.com/Anionex/dsh-vision-toolkit/compare/9835075c2eedab21ac895209a0c1d85074c1fe91...64932217cf0194c50ee78dfc580e886ef2355300
+[0.1.0]: https://github.com/Anionex/dsh-vision-toolkit/commit/9835075c2eedab21ac895209a0c1d85074c1fe91

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Version `0.1.4` is the current public npm release. P0 and P1 are product commitm
 ## Community and About
 
 - Read [CONTRIBUTING.md](CONTRIBUTING.md) before proposing code, protocol, or upstream-snapshot changes.
-- Use [GitHub Issues](https://github.com/dsh-external/dsh-vision-toolkit/issues) for reproducible bugs, focused feature requests, and usage questions; use [SUPPORT.md](SUPPORT.md) to choose the right channel.
+- Use [GitHub Issues](https://github.com/Anionex/dsh-vision-toolkit/issues) for reproducible bugs, focused feature requests, and usage questions; use [SUPPORT.md](SUPPORT.md) to choose the right channel.
 - Report vulnerabilities privately through the process in [SECURITY.md](SECURITY.md), never in a public issue.
 - Follow releases and compatibility notes in [CHANGELOG.md](CHANGELOG.md).
 - Optional sponsorship is described transparently in [FUNDING.md](FUNDING.md); support does not purchase roadmap priority or private support.

--- a/README.zh.md
+++ b/README.zh.md
@@ -364,7 +364,7 @@ pnpm pack --dry-run
 ## 社区与关于
 
 - 提交代码、协议或上游快照变更前，请先阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
-- 可复现缺陷、范围明确的功能建议和使用问题请提交到 [GitHub Issues](https://github.com/dsh-external/dsh-vision-toolkit/issues)；如何选择渠道见 [SUPPORT.md](SUPPORT.md)。
+- 可复现缺陷、范围明确的功能建议和使用问题请提交到 [GitHub Issues](https://github.com/Anionex/dsh-vision-toolkit/issues)；如何选择渠道见 [SUPPORT.md](SUPPORT.md)。
 - 安全漏洞必须按 [SECURITY.md](SECURITY.md) 私下报告，不要创建公开 Issue。
 - 版本与兼容性变化记录在 [CHANGELOG.md](CHANGELOG.md)。
 - 可选赞助方式与用途见 [FUNDING.md](FUNDING.md)；赞助不购买路线图优先级或私有支持。

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,7 +5,7 @@
 - Read the [README](README.md) for installation, configuration, usage, security, scope, and troubleshooting.
 - Check the [requirements traceability reference](docs/requirements-traceability/README.md) when you need the implementation or verification home for a product requirement.
 - Reproduce visual-verification issues with the checked-in [UI restoration example](examples/ui-restoration/README.md).
-- Search existing [issues](https://github.com/dsh-external/dsh-vision-toolkit/issues) and [pull requests](https://github.com/dsh-external/dsh-vision-toolkit/pulls) before opening a duplicate.
+- Search existing [issues](https://github.com/Anionex/dsh-vision-toolkit/issues) and [pull requests](https://github.com/Anionex/dsh-vision-toolkit/pulls) before opening a duplicate.
 
 ## Where to ask
 
@@ -15,7 +15,7 @@
 - Security concern: follow [SECURITY.md](SECURITY.md) and report it privately.
 - Code contribution: read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
-Open the repository's [issue chooser](https://github.com/dsh-external/dsh-vision-toolkit/issues/new/choose) to select the appropriate form.
+Open the repository's [issue chooser](https://github.com/Anionex/dsh-vision-toolkit/issues/new/choose) to select the appropriate form.
 
 ## Information to include
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="The DeepSeek Harness-native integration for agent-vision-toolkit: intent-aware image Q&amp;A, OCR, grounding, UI restoration, pixel verification, Artifacts, and Web UI." />
     <meta property="og:title" content="DSH Vision Toolkit — agent-vision-toolkit for DeepSeek Harness" />
     <meta property="og:description" content="Give text-only DSH agents eyes, with vision mounted in the harness instead of built into the base model." />
-    <meta property="og:image" content="https://github.com/dsh-external/dsh-vision-toolkit/raw/main/assets/social-preview.png" />
+    <meta property="og:image" content="https://github.com/Anionex/dsh-vision-toolkit/raw/main/assets/social-preview.png" />
     <meta name="theme-color" content="#5b4cf0" />
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='18' fill='%235b4cf0'/%3E%3Cpath d='M13 46 25 34l11-16M25 34h20M45 34l7 12' fill='none' stroke='white' stroke-width='5' stroke-linecap='round'/%3E%3C/svg%3E" />
     <style>
@@ -531,8 +531,8 @@
           <a href="#capabilities">Capabilities</a>
           <a href="#install">Install</a>
           <a href="https://agent-vision.anionex.me">Upstream</a>
-          <a href="https://github.com/dsh-external/dsh-vision-toolkit/blob/main/README.zh.md">中文</a>
-          <a href="https://github.com/dsh-external/dsh-vision-toolkit">GitHub</a>
+          <a href="https://github.com/Anionex/dsh-vision-toolkit/blob/main/README.zh.md">中文</a>
+          <a href="https://github.com/Anionex/dsh-vision-toolkit">GitHub</a>
         </div>
       </nav>
 
@@ -652,9 +652,9 @@
             <div class="section-label">Quick start</div>
             <h2>Install one checkout into the profiles you use.</h2>
             <p>Requires DeepSeek Harness, Python 3.11+, and <code>pnpm</code> available to <code>dsh plugin</code>. Restart a running Web profile, then configure the visual endpoint and DSH Credential in Settings.</p>
-            <a class="button" href="https://github.com/dsh-external/dsh-vision-toolkit#quick-start">Full installation and security guide</a>
+            <a class="button" href="https://github.com/Anionex/dsh-vision-toolkit#quick-start">Full installation and security guide</a>
           </div>
-          <pre><code>git clone https://github.com/dsh-external/dsh-vision-toolkit.git
+          <pre><code>git clone https://github.com/Anionex/dsh-vision-toolkit.git
 PLUGIN="$PWD/dsh-vision-toolkit"
 
 dsh plugin --profile web add "$PLUGIN"
@@ -667,7 +667,7 @@ dsh --profile web --dump-config | grep vision-toolkit</code></pre>
 
     <footer class="shell">
       <span>DeepSeek Harness integration for agent-vision-toolkit · MIT · Anionex</span>
-      <span><a href="https://agent-vision.anionex.me">Website</a> · <a href="https://github.com/Anionex/agent-vision-toolkit">Upstream</a> · <a href="https://github.com/dsh-external/dsh-vision-toolkit">DSH repository</a></span>
+      <span><a href="https://agent-vision.anionex.me">Website</a> · <a href="https://github.com/Anionex/agent-vision-toolkit">Upstream</a> · <a href="https://github.com/Anionex/dsh-vision-toolkit">DSH repository</a></span>
     </footer>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dsh-external/dsh-vision-toolkit.git"
+    "url": "git+https://github.com/Anionex/dsh-vision-toolkit.git"
   },
   "bugs": {
-    "url": "https://github.com/dsh-external/dsh-vision-toolkit/issues"
+    "url": "https://github.com/Anionex/dsh-vision-toolkit/issues"
   },
   "homepage": "https://agent-vision.anionex.me",
   "funding": "https://ifdian.net/a/anionex",

--- a/scripts/verify-portable.mjs
+++ b/scripts/verify-portable.mjs
@@ -115,8 +115,8 @@ const pkg = JSON.parse(await readFile(packagePath, 'utf8'))
 
 check(pkg.name === '@dsh-external/dsh-vision-toolkit', 'package name must stay @dsh-external/dsh-vision-toolkit')
 check(pkg.version === '0.1.2', 'package version and the latest release notes must stay aligned')
-check(pkg.repository?.url === 'git+https://github.com/dsh-external/dsh-vision-toolkit.git', 'repository URL is missing or mismatched')
-check(pkg.bugs?.url === 'https://github.com/dsh-external/dsh-vision-toolkit/issues', 'issue tracker URL is missing or mismatched')
+check(pkg.repository?.url === 'git+https://github.com/Anionex/dsh-vision-toolkit.git', 'repository URL is missing or mismatched')
+check(pkg.bugs?.url === 'https://github.com/Anionex/dsh-vision-toolkit/issues', 'issue tracker URL is missing or mismatched')
 check(pkg.homepage === 'https://agent-vision.anionex.me', 'homepage URL is missing or mismatched')
 check(pkg.funding === 'https://ifdian.net/a/anionex', 'funding metadata is missing or mismatched')
 check(pkg.engines?.node === '^22.19.0 || >=24.0.0', 'Node.js engine range must match DeepSeek Harness')
@@ -169,6 +169,23 @@ const requiredFiles = [
 ]
 for (const path of requiredFiles) {
   check(await exists(join(root, path)), `required file is missing: ${path}`)
+}
+
+const publicRepositoryFiles = [
+  '.github/ISSUE_TEMPLATE/config.yml',
+  'CHANGELOG.md',
+  'README.md',
+  'README.zh.md',
+  'SUPPORT.md',
+  'index.html',
+  'package.json',
+]
+for (const path of publicRepositoryFiles) {
+  const content = await readFile(join(root, path), 'utf8')
+  check(
+    !content.includes('https://github.com/dsh-external/dsh-vision-toolkit'),
+    `${path} still links to the retired dsh-external repository`,
+  )
 }
 
 await verifyWindowsCheckout()


### PR DESCRIPTION
## Summary

- Point public repository, issue, support, changelog, landing-page, and package metadata links at `Anionex/dsh-vision-toolkit` while keeping the npm package name `@dsh-external/dsh-vision-toolkit` unchanged.
- Update the landing page URLs that the original patch missed.
- Use existing public commit ranges for the historical `0.1.0`-`0.1.2` changelog links, because those historical tags remain only in the former private repository. The current `v0.1.4` public release remains owned by `main`.
- Update `scripts/verify-portable.mjs` to validate the new package metadata and reject the retired public repository URL across the public project surfaces.

## Windows guidance review

The original Windows notes were removed rather than rewritten:

| Original note | Final treatment | Evidence |
|---|---|---|
| Disable `core.autocrlf` before cloning | Removed | #14 added `.gitattributes` byte preservation and a real `core.autocrlf=true` checkout regression to the portable gate. |
| Manually install/link out-of-tree dependencies | Removed | #14 switched to the host-provided namespaced schema peer and verified a clean tarball/profile install without the junction workaround. |
| Override WindowsApps Python stubs | Removed as a dedicated workaround | #4 probes candidates and resolves the selected interpreter to an absolute executable before `uv`; the existing `runtime.python` reference already documents the supported override. #13 separately enforces UTF-8 subprocess and trace contracts. |

No Windows workaround section remains in the diff.

## Copilot inline comments

- `index.html` still used the old repository: fixed all six landing-page occurrences.
- `scripts/verify-portable.mjs` expected the old metadata: fixed and covered with a retired-URL regression check.
- The two `autocrlf` command comments are superseded because the obsolete workaround was removed entirely.

All four comments are addressed by the updated diff.

## Verification

Passed:

- `git diff --check vision-upstream/main...HEAD`
- `npm run verify:portable` — 26 required files, 21 JavaScript files, 24 images; includes `npm pack --dry-run --ignore-scripts`
- retired public repository URL scan across README, support, issue template, changelog, landing page, and package metadata
- bilingual README repository URL comparison
- HTTP checks for the changed repository, Issues, Support, landing-page assets, current `v0.1.4` release, and historical changelog commit ranges — all returned `200`
- fresh adversarial Codex review — no reasonable high-value actionable findings

Full TypeScript build/tests are not claimed from this isolated out-of-tree worktree. The package's TypeScript configuration intentionally resolves DSH source types through sibling `../packages` and `../vendor` paths. A build attempt with the available newer local DSH facade failed on pre-existing API type mismatches, and standalone dependency installation failed because the `@deepseek-ai/dsh-*` peer packages are not published at the declared `^0.0.1` ranges. The dependency-free portable/package gate above is the relevant acceptance path for this documentation and verifier-only change.

This PR has not been merged.
