### PR TITLE
docs: move community QR near quick start

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write dsh-vision-dark-theme/README.md
-README.md: 026285db53ab41b5e70527060c692bf9f2785541
-README.zh.md: df34e29906568cd13f235dad56abe652a659a620
+README.md: 2a05d467a5c0cff82900d6074220392553f5d972
+README.zh.md: 07cff26ce48a7f0df6791ac9723debaeb723d5f4

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Legacy profiles must use `nodeLinker: hoisted` and `autoInstallPeers: false` in 
 
 Restart a running Web profile, open **Settings → Vision Toolkit**, select a DSH Credential for remote tools, run **Test API connection**, and then run **Test vision model** to verify one real image request. In a conversation, make an image available as a workspace path, invoke `/vision-tools`, and ask the Agent to call a specific `vision_*` tool. Local crop, trace, pixel, color, foreground, and HTML operations do not require a visual API credential.
 
+## Community Group
+
+Join the `agent-vision-toolkit` community group to exchange usage tips, share feedback, and suggest improvements.
+
+<p align="center">
+  <img src="assets/community-group-qr.png" alt="QR code for the agent-vision-toolkit community group" width="260">
+</p>
+
 ## How it works
 
 ```mermaid
@@ -341,11 +349,6 @@ npm run example:ui-restoration:write
 
 The committed evidence records an initial `6.04%` difference across six non-zero worst regions and a final `0%` difference with no non-zero worst region. Check mode reproduces the tool path and verifies the committed assets; write mode intentionally refreshes the evidence.
 
-## Communication group
-
-<img width="254" height="328" alt="image" src="https://github.com/user-attachments/assets/63c25c69-c3ba-4c47-8dee-98d60fe3954d" />
-
-
 ## Troubleshooting
 
 | Symptom | Resolution |
@@ -401,11 +404,3 @@ If you would like to follow my future work, [follow me on X](https://x.com/anion
 ## License
 
 The plugin is MIT-licensed. The packaged `agent-vision-toolkit` snapshot retains its upstream MIT license in `vendor/agent-vision-toolkit/LICENSE` and remains the sole implementation of its visual algorithms.
-
-## Join the Community Group
-
-You are welcome to join the `agent-vision-toolkit` community group to exchange usage tips, share feedback, and suggest improvements. Scan the QR code below to join.
-
-<p align="center">
-  <img src="assets/community-group-qr.png" alt="QR code for the agent-vision-toolkit community group" width="320">
-</p>

--- a/README.zh.md
+++ b/README.zh.md
@@ -103,6 +103,14 @@ dsh --profile headless --dump-config | grep vision-toolkit
 
 安装后重启正在运行的 Web Profile，打开 **设置 → 视觉工具**，为远程工具选择 DSH Credential，先执行**测试 API 连接**，再执行**测试视觉模型**以验证一次真实图片请求。在会话中把图片放进工作区路径，调用 `/vision-tools`，再让 Agent 使用明确的 `vision_*` 工具。本地裁剪、SVG、像素、颜色、前景和 HTML 操作不需要视觉 API Credential。
 
+## 加入交流群
+
+欢迎加入 `agent-vision-toolkit` 项目交流群，交流使用经验、反馈问题并提出建议。
+
+<p align="center">
+  <img src="assets/community-group-qr.png" alt="agent-vision-toolkit 项目交流群二维码" width="260">
+</p>
+
 ## 工作原理
 
 ```mermaid
@@ -409,11 +417,3 @@ pnpm pack --dry-run
 ## 许可证
 
 插件采用 MIT 许可。打包的 `agent-vision-toolkit` 快照在 `vendor/agent-vision-toolkit/LICENSE` 保留上游 MIT 许可证，并继续作为视觉算法的唯一实现。
-
-## 加入交流群
-
-欢迎加入 `agent-vision-toolkit` 项目交流群，交流使用经验、反馈问题并提出建议。请扫描下方二维码入群。
-
-<p align="center">
-  <img src="assets/community-group-qr.png" alt="agent-vision-toolkit 项目交流群二维码" width="320">
-</p>


### PR DESCRIPTION
## Summary

- Move the community-group QR block directly after Quick Start in both README languages.
- Remove the duplicate English community sections and the external GitHub attachment.
- Use the checked-in QR asset at a smaller 260 px width and refresh bilingual pairing hashes.

## Verification

- `git diff --check`
- `pnpm run verify:portable`

Documentation presentation only; no runtime behavior changed.
