### PR TITLE
docs: rewrite README around user outcomes

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,6 +1,6 @@
 # Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
-#   pnpm run verify-translation-pairing --write dsh-vision-dark-theme/README.md
-README.md: 637b7ffe18a004955360dc2da3c47a8f0ea29b38
-README.zh.md: 8255113e0dae138d39cf97d9dc134b91c0ae0f73
+#   pnpm run verify-translation-pairing --write dsh-vision-toolkit/README.md
+README.md: 9c8fca9f095c7669d8e36edd4f84cb19ba3186d5
+README.zh.md: 236e30c1d883de32b45ff81a338d2514bb40d520

--- a/README.md
+++ b/README.md
@@ -1,470 +1,311 @@
 <p align="center">
-  <img src="assets/hero-v2.png" alt="DSH Vision Toolkit — native visual engineering for text-only DeepSeek Harness agents" />
+  <img src="assets/hero-v2.png" alt="DSH Vision Toolkit helps text-only DeepSeek Harness agents understand images and complete visual tasks" />
 </p>
 
-<h1 align="center">DSH Vision Toolkit</h1>
+<div align="center">
 
-<p align="center">
-  English | <a href="https://github.com/Anionex/dsh-vision-toolkit/blob/main/README.zh.md">中文</a>
-</p>
+# DSH Vision Toolkit
 
-<p align="center">
-  <a href="https://dshfind.com/en/plugins/Anionex/dsh-vision-toolkit"><img src="https://img.shields.io/badge/recommended%20by-dshfind-FFD700?style=flat-square" alt="Recommended by dshfind" /></a>
-  <a href="https://dshfind.com/en/plugins/Anionex/dsh-vision-toolkit"><img src="https://img.shields.io/badge/dshfind%20score-94%20%7C%20highest--rated%20plugin-5B4CF0?style=flat-square" alt="dshfind score: 94 — highest-rated plugin" /></a>
-  <a href="https://x.com/anion_ex"><img src="https://img.shields.io/badge/-@anion__ex-000000?style=flat-square&amp;logo=x&amp;logoColor=white" alt="X: @anion_ex" /></a>
-  <a href="https://github.com/Anionex/dsh-vision-toolkit/releases/tag/v0.1.12"><img src="https://img.shields.io/badge/release-v0.1.12-5B4CF0?style=flat-square" alt="Release v0.1.12" /></a>
-  <a href="tests"><img src="https://img.shields.io/badge/verified-233%20tests-2EA44F?style=flat-square" alt="Verified: 233 tests" /></a>
-</p>
+[![Recommended by dshfind](https://img.shields.io/badge/recommended%20by-dshfind-FFD700?style=flat-square)](https://dshfind.com/en/plugins/Anionex/dsh-vision-toolkit)
+[![npm](https://img.shields.io/npm/v/@anionex/dsh-vision-toolkit?style=flat-square&color=5B4CF0)](https://www.npmjs.com/package/@anionex/dsh-vision-toolkit)
+[![MIT](https://img.shields.io/badge/license-MIT-0B7285?style=flat-square)](LICENSE)
+[![DSH](https://img.shields.io/badge/DSH-Web%20%2B%20Headless-5B4CF0?style=flat-square)](cordis.patch.yml)
 
-<p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-0B7285?style=flat-square" alt="License: MIT" /></a>
-  <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%5E22.19%20%7C%20%3E%3D24-339933?style=flat-square&amp;logo=nodedotjs&amp;logoColor=white" alt="Node.js ^22.19 or >=24" /></a>
-  <a href="runtime/requirements.lock"><img src="https://img.shields.io/badge/Python-3.11%2B-3776AB?style=flat-square&amp;logo=python&amp;logoColor=white" alt="Python 3.11+" /></a>
-  <a href="cordis.patch.yml"><img src="https://img.shields.io/badge/DSH-Web%20%2B%20Headless-5B4CF0?style=flat-square" alt="DSH Web and Headless profiles" /></a>
-</p>
+**Give text-only DSH agents eyes: paste an image, ask a question, locate exact elements, extract assets, and verify UI restoration with measurable results.**
 
-## Give your DSH agent eyes
+🌐 **English** | [中文](README.zh.md)
 
-Drop in a screenshot and let a text-only DeepSeek Harness agent inspect it, read it, locate elements, extract assets, rebuild interfaces, and measure whether the result matches.
+</div>
 
-DSH Vision Toolkit packages [`agent-vision-toolkit`](https://github.com/Anionex/agent-vision-toolkit) as a native DSH plugin. You get focused image Q&A, OCR, original-pixel coordinates, UI restoration, pixel comparison, downloadable results, and a Web Settings panel without assembling scripts by hand.
+When you run DeepSeek or another text-only model in DeepSeek Harness (DSH), familiar problems appear quickly: the model cannot see a screenshot, generic image descriptions miss the point, buttons have no usable coordinates, and a rebuilt page may look “close enough” without any way to measure the remaining difference.
+
+DSH Vision Toolkit packages [`agent-vision-toolkit`](https://github.com/Anionex/agent-vision-toolkit) as a native DSH plugin. It helps an agent do more than describe an image: the agent can read, locate, crop, trace, rebuild, and verify visual work around the task at hand.
+
+> **Install and use it immediately.** The default setup includes a free Gemma 4 vision service and requires no API key. Cropping, pixel diffing, color analysis, foreground extraction, SVG tracing, and HTML screenshots run locally without spending vision API requests.
 
 ```sh
 dsh plugin --profile web add @anionex/dsh-vision-toolkit
 ```
-
-The npm package includes the visual toolkit snapshot and uses a managed runtime by default. **Normal installation does not require a source checkout or an `agentVisionToolkitPath`.**
 
 **Upstream toolkit:** [Anionex/agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) · **Project website:** [agent-vision.anionex.me](https://agent-vision.anionex.me)
 
-## What you can do
+<details>
+<summary><strong>Table of contents</strong></summary>
 
-| Goal | What the agent can deliver |
+- [Recent updates](#recent-updates)
+- [Problems it solves](#problems-it-solves)
+- [See it in action](#see-it-in-action)
+- [Highlights](#highlights)
+- [Quick start: three steps](#quick-start-three-steps)
+- [Common workflows](#common-workflows)
+- [Toolbox](#toolbox)
+- [Configuration and limits](#configuration-and-limits)
+- [Troubleshooting](#troubleshooting)
+- [Development and community](#development-and-community)
+
+</details>
+
+## Recent updates
+
+- **2026-08-16 · Windows Python:** Added Microsoft Store Python support, fixing first-time isolated-runtime setup failures for affected Windows users.
+- **2026-08-16 · Better free vision:** Switched the default model to Gemma 4, improving the no-key image-understanding path.
+- **2026-08-16 · Image paste:** Text-only routes now switch to a `(Vision Toolkit)` variant and keep a workspace path, fixing blocked pastes and images that could not be reused later.
+- **2026-08-16 · Higher free quotas:** Raised per-client, global, and burst limits to `100/day`, `400/day`, and `20/minute`, reducing avoidable rate-limit failures while the shared capacity is lightly used.
+- **2026-08-16 · Real model test:** Added a full image-request test in Settings, fixing the false confidence caused by a successful `/models` request to a model that still cannot process images.
+
+## Problems it solves
+
+| The problem | What Vision Toolkit delivers |
 |---|---|
-| Understand a screenshot | Focused answers, visual descriptions, multi-image comparison, and OCR |
-| Find an interface element | Original-image pixel coordinates with an optional labeled preview |
-| Rebuild a page from a reference | Screenshot rendering, region-by-region diagnosis, and measurable iteration |
-| Extract a usable asset | Cropped images, transparent foregrounds, dominant colors, or editable SVG |
-| Read a long screenshot | Auditable chunks, Markdown output, manifests, and resumable OCR runs |
-| Verify a visual result | A difference percentage, ranked mismatch regions, heatmap, and JSON report |
-
-You can use remote vision only where it adds value. Cropping, tracing, pixel comparison, color analysis, foreground extraction, and HTML screenshots run locally.
+| **A text-only model cannot see a screenshot** | Paste an image in DSH Web; the plugin obtains visual evidence and returns the task-relevant parts to the text model |
+| **The description is long but misses the point** | Ask “Where is the error?” or “What color is the submit button?” and receive an answer focused on that question |
+| **The model knows an element exists but cannot act on it** | Get original-image pixel coordinates and an optional labeled or numbered preview |
+| **Long-screenshot OCR skips or duplicates lines** | Split and audit the image while preserving Markdown, chunks, manifests, and resumable run state |
+| **UI restoration is judged by feel** | Compare the reference and implementation screenshots to get a difference percentage, ranked regions, a heatmap, and JSON |
+| **Screenshot assets cannot be reused** | Produce a crop, transparent PNG, color palette, or editable SVG instead of stopping at prose |
 
 ## See it in action
 
-The first example is a live DSH Web view. The next two examples come from the same `agent-vision-toolkit` lineage packaged with this plugin, and the last shows the workflow inside a live DeepSeek Harness Web session. See the [asset provenance record](assets/upstream/README.md) for source details.
-
-### DSH view example
+### Paste an image directly into DSH
 
 <p align="center">
-  <img src="assets/dsh-view-example.png" width="80%" alt="DSH Web session view in which a text-only DeepSeek-V4-Flash (Vision Toolkit) model answers a question about a pasted banner image." />
+  <img src="assets/dsh-view-example.png" width="82%" alt="A text-only DeepSeek model answering a question about a pasted image through Vision Toolkit in DSH Web" />
 </p>
 
-*A live DSH Web view: the user pastes a brand-banner screenshot, and the text-only model answers what the image contains through the `DeepSeek-V4-Flash (Vision Toolkit)` image-input variant.*
+*Paste an image into the conversation. A text-only model can switch to its `Vision Toolkit` variant and inspect the image in the context of the user's question.*
 
-### Infographic restoration: screenshot to editable HTML/CSS
+### Screenshot to editable page
 
 <p align="center">
-  <img src="assets/upstream/infographic-reference.webp" width="49%" alt="Upstream reference screenshot of a three-stage model-training infographic." />
-  <img src="assets/upstream/infographic-result.webp" width="49%" alt="Upstream editable HTML and CSS reconstruction of the model-training infographic." />
+  <img src="assets/upstream/infographic-reference.webp" width="49%" alt="Reference infographic screenshot used for restoration" />
+  <img src="assets/upstream/infographic-result.webp" width="49%" alt="Editable HTML and CSS reconstruction created from the reference screenshot" />
 </p>
 
-*Left: source screenshot. Right: the editable HTML/CSS result from the upstream [infographic-restoration reference](https://github.com/Anionex/agent-vision-toolkit/blob/c27d1a300962b553c0884993c575cd3e819465ce/examples/infographic-restoration/how-is-the-model-trained.html).*
+*Left: the reference screenshot. Right: an editable HTML/CSS result. The result can continue into screenshot rendering and pixel comparison instead of ending as an image description.*
 
-### UI restoration: sketch to working interface
+### Sketch to working interface
 
 <p align="center">
-  <img src="assets/upstream/ui-sketch.webp" width="49%" alt="Upstream hand-drawn JupyterLab workspace used as a UI restoration reference." />
-  <img src="assets/upstream/ui-result.webp" width="49%" alt="Upstream JupyterLab-style working interface reconstructed from the hand-drawn reference." />
+  <img src="assets/upstream/ui-sketch.webp" width="49%" alt="Hand-drawn JupyterLab interface used as the restoration reference" />
+  <img src="assets/upstream/ui-result.webp" width="49%" alt="Working JupyterLab-style interface reconstructed from the sketch" />
 </p>
 
-*Left: hand-drawn input. Right: the upstream reconstructed interface; the complete method lives in the [UI restoration playbook](https://github.com/Anionex/agent-vision-toolkit/blob/c27d1a300962b553c0884993c575cd3e819465ce/skills/vision-tools/references/restore-ui.md).*
+*Left: a hand-drawn reference. Right: the working interface reconstructed from it.*
 
-### Image Q&A and screenshot-guided debugging
+### Turn “looks close” into a verifiable result
 
-<p align="center">
-  <img src="assets/dsh-conversation-image-qa.png" width="49%" alt="DSH Web session in which a text-only agent answers a focused question about a UI reference image." />
-  <img src="assets/dsh-conversation-screenshot-debugging.png" width="49%" alt="DSH Web session in which the agent uses a screenshot comparison to diagnose mismatched UI fields and recommend vision_pixel_diff." />
-</p>
-
-*Left: intent-aware image Q&A in DSH Web. Right: a DSH Web screenshot-debugging turn that lists the concrete UI differences and continues toward `vision_pixel_diff`. The upstream workflow source is the same [`agent-vision-toolkit` reference](https://github.com/Anionex/agent-vision-toolkit/blob/c27d1a300962b553c0884993c575cd3e819465ce/README.md#real-world-effects).*
-
-DSH Vision Toolkit brings this workflow into DSH, where the result can become a file, a coordinate, a measured comparison, or the next step in the same session.
-
-## From a rough match to pixel-perfect
-
-The included UI-restoration workflow starts with an intentionally inaccurate HTML implementation. Vision Toolkit measures a `6.04%` difference, points to the worst regions, and helps drive the next iteration. The final render reaches an exact `0%` difference at `1200 × 720`.
+The repository includes a reproducible UI-restoration example. The first implementation differs from the reference by **6.04%**. After the highlighted regions are corrected, the final `1200 × 720` render reaches **0% pixel difference**.
 
 <p>
-  <img src="examples/ui-restoration/assets/initial.png" width="49%" alt="Initial UI restoration candidate before Vision Toolkit iteration, with measurable layout and styling differences from the reference." />
-  <img src="examples/ui-restoration/assets/implementation.png" width="49%" alt="Final UI restoration output reproduced by the checked-in workflow with zero pixel difference from the reference." />
+  <img src="examples/ui-restoration/assets/initial.png" width="49%" alt="Initial UI implementation with measurable layout and styling differences" />
+  <img src="examples/ui-restoration/assets/implementation.png" width="49%" alt="Final UI implementation after visual diagnosis, reaching zero pixel difference" />
 </p>
 
-| Start | Result |
-|---|---|
-| Reference image | A working HTML implementation you can open and edit |
-| First comparison | `6.04%` difference across the visible problem regions |
-| Final comparison | `0%` difference at `1200 × 720` |
+## Highlights
 
-## Why it feels different
+- **Free by default.** New installations use the built-in Gemma 4 service without requiring another account or API key.
+- **Focused on the current task.** The agent sends the reason it needs to inspect the image, so the result emphasizes useful evidence instead of producing a generic caption.
+- **Outputs you can keep working with.** Coordinates, OCR, transparent PNGs, SVGs, screenshots, heatmaps, and JSON can feed directly into the next step.
+- **Built for UI and screenshot work.** Reference analysis, element location, asset extraction, HTML rendering, and pixel comparison form one continuous workflow.
+- **Local where possible.** Crop, trace, pixel diff, color, foreground, and HTML screenshot operations do not need a remote vision model.
+- **The same capabilities in Web and Headless.** Web users can preview and download artifacts; Headless runs still receive replayable structured results and workspace paths.
 
-- **Ask for the thing you need.** “Where is the submit button?” and “Why does this screenshot differ from the reference?” lead to focused visual work instead of a generic caption.
-- **Get evidence you can use.** The agent returns coordinates, OCR, measurements, JSON, and files you can open or pass to the next step.
-- **Keep the workflow in DSH.** Credentials, Settings, Artifacts, Web cards, and Headless results live alongside the rest of your session.
-- **Use local tools when you can.** Crop, trace, pixel comparison, color analysis, foreground extraction, and HTML screenshots do not consume a vision API request.
-- **Repeat the loop.** Reference image → implementation → screenshot → pixel diff gives UI work a measurable finish line.
+## Quick start: three steps
 
-## Start in three steps
-
-Use DeepSeek Harness `0.1.0-rc.6` or a compatible later `0.1.x` release. The plugin prepares its managed runtime on first use.
+### 1. Install
 
 ```sh
 dsh plugin --profile web add @anionex/dsh-vision-toolkit
+```
+
+You can install it into a Headless Profile too:
+
+```sh
 dsh plugin --profile headless add @anionex/dsh-vision-toolkit
 ```
 
-1. Restart your Web profile and open **Settings → Vision Toolkit**.
-2. New installations use the built-in free Gemma 4 provider, so you can run **Test API connection** and **Test vision model** without an API key. To use another provider, edit the endpoint/model/protocol and provide its DSH Credential.
-3. In a conversation, paste an image or put it in the workspace, invoke `/vision-tools`, and ask for a concrete visual task.
+### 2. Restart and check it
 
-If you use an older DSH launcher, the profile may need `nodeLinker: hoisted` and `autoInstallPeers: false` before installation. Current launchers repair these settings for you.
+Restart a running Web Profile, then open **Settings → Vision Toolkit**. The free provider is already configured; run **Test vision model** to confirm it is reachable.
 
-Local crop, trace, pixel, color, foreground, and HTML operations do not require a visual API credential.
+The first start prepares an isolated runtime, so it needs access to the Python package cache or the network. A normal installation does not require an `agent-vision-toolkit` source checkout or a local path setting.
 
-## Community Group
+### 3. Paste an image and describe the outcome you want
 
-Join the `agent-vision-toolkit` community group to exchange usage tips, share feedback, and suggest improvements.
+Paste a screenshot into the conversation or place an image in the session workspace, then invoke `/vision-tools`. For example:
 
-<p align="center">
-  <img src="assets/community-group-qr.png" alt="QR code for the agent-vision-toolkit community group" width="260">
-</p>
+```text
+Inspect this screenshot. Explain the error and tell me what to fix first.
+Find the login button in the top-right corner, return original pixel coordinates, and make a boxed preview.
+Crop this icon and convert it to SVG.
+Rebuild the page from reference.png. After each pass, render it and run a pixel diff until the major differences are gone.
+```
 
-> **No local path is required.** Keep the default `runtime.mode: managed` for the normal npm installation. The optional `runtime.agentVisionToolkitPath` setting is only for developers or controlled deployments that deliberately use an external pinned checkout.
+## Common workflows
 
-<details>
-<summary><strong>Technical architecture</strong></summary>
+| Task | Recommended workflow |
+|---|---|
+| Image Q&A or screenshot debugging | Inspect → answer around the current question → locate details when needed |
+| Find a button, icon, or text region | Ground the target → return pixel box → create a labeled preview |
+| Extract an icon from a screenshot | Ground → crop → trace to SVG |
+| Read a long webpage screenshot | Split → OCR → merge Markdown → audit boundaries |
+| Recreate a page or component | Reference → implementation → HTML screenshot → pixel diff → iterate |
+| Extract brand visuals | Crop region → analyze dominant colors → extract foreground → export transparent PNG |
+
+## Toolbox
+
+The plugin provides 10 tools that can be called independently or composed into a workflow:
+
+| Tool | Best question to ask | Main result |
+|---|---|---|
+| `vision_glance` | “What is happening in this image?” | Focused answer, description, OCR, or multi-image comparison |
+| `vision_ground` | “Where is the thing I need?” | Original pixel coordinates and optional boxed preview |
+| `vision_detect` | “Which buttons, icons, or elements are present?” | Numbered element inventory, coordinates, and optional preview |
+| `vision_crop` | “Extract this region as its own image” | PNG or JPEG crop |
+| `vision_trace` | “Turn this shape into an editable vector” | SVG |
+| `vision_pixel_diff` | “Where does the implementation differ from the reference?” | Difference percentage, ranked regions, heatmap, and JSON |
+| `vision_long_screenshot_ocr` | “Read this entire long screenshot” | Markdown, chunks, manifest, and audit output |
+| `vision_extract_foreground` | “Remove the background from this subject” | Transparent PNG |
+| `vision_dominant_colors` | “Which colors dominate this area?” | Palette or ranked candidate colors |
+| `vision_html_screenshot` | “Render this local page at an exact viewport” | PNG |
+
+Coordinates always use original-image pixels in `x1,y1,x2,y2` form, so grounding output can feed directly into cropping, tracing, or later automation.
 
 ## How it works
 
-```mermaid
-flowchart LR
-    User["Workspace image or local HTML"] --> Skill["vision-tools Skill"]
-    Skill --> Activate["Agent-scoped activation"]
-    Activate --> Tools["10 independent vision_* tools"]
-    Tools --> Runtime["Shared VisionToolkitRuntime"]
-    Credentials["DSH Credentials"] --> Runtime
-    Settings["Web Settings and health"] --> Runtime
-    Runtime --> Upstream["Pinned agent-vision-toolkit"]
-    Runtime --> Remote["Configured vision API"]
-    Upstream --> Result["Text, coordinates, JSON"]
-    Remote --> Result
-    Runtime --> Artifacts["Workspace Artifacts"]
-    Result --> Session["Reconstructable Session log"]
-    Artifacts --> Web["Preview, download, or open file"]
-```
-
-Tool definitions call one runtime; the runtime validates paths, limits, credentials, cancellation, and deadlines before dispatching to the pinned upstream snapshot or configured vision provider endpoint. Web presentation consumes the same structured results and Artifact descriptors, so it does not change Headless behavior. Health, connection testing, and version inspection stay in Settings rather than model tool schemas.
-
-</details>
-
-## Tools
-
-| Tool | Execution | Structured result | Artifact delivery |
-|---|---|---|---|
-| `vision_glance` | Remote vision API | Description, targeted answer, OCR, or multi-image comparison | None |
-| `vision_ground` | Remote vision API; optional local preview | Target, original-image dimensions, and pixel boxes | Optional labeled PNG |
-| `vision_detect` | Remote vision API; optional local preview | Numbered element inventory and original-image pixel boxes | Optional numbered PNG |
-| `vision_trace` | Local pinned vtracer pipeline | SVG geometry status, path count, scale, and size | SVG |
-| `vision_crop` | Local Pillow pipeline | Applied pixel box, dimensions, format, and clamp status | PNG or JPEG |
-| `vision_pixel_diff` | Local NumPy/Pillow pipeline | Difference percentage and ranked grid regions | PNG heatmap and JSON report |
-| `vision_long_screenshot_ocr` | Local split/audit; remote OCR unless `splitOnly=true` | Chunk boundaries, reuse state, completion state, and run directory | Markdown, manifest, boundary audit, chunk PNGs, and OCR sidecars |
-| `vision_extract_foreground` | Local pinned extraction pipeline | Selected box, component counts, foreground coverage, and dimensions | Transparent PNG |
-| `vision_dominant_colors` | Local pinned color analysis | Extracted palette or pixel-backed candidate ranking | None |
-| `vision_html_screenshot` | Local Chrome/Chromium/Edge adapter | Authorized source facts, viewport, and rendered dimensions | PNG |
-
-The plugin does not reimplement visual algorithms. Its DSH-owned layer validates paths and limits, resolves credentials, calls the pinned upstream scripts with argv vectors, parses their exact output contracts, classifies failures, describes files, and projects results to the model and Web client.
+The plugin keeps image understanding and deterministic local image processing in one Agent workflow. Expand the flow below for the implementation boundary.
 
 <details>
-<summary><strong>Advanced model behavior</strong></summary>
+<summary><strong>Architecture and image-input behavior</strong></summary>
 
-## Progressive model exposure
+```mermaid
+flowchart LR
+    Image["Screenshot or local HTML"] --> Skill["vision-tools Skill"]
+    Skill --> Agent["Text agent selects a task"]
+    Agent --> Vision["Use a vision model when image understanding is needed"]
+    Agent --> Local["Run crop, SVG, and pixel work locally"]
+    Vision --> Result["Answer, OCR, coordinates"]
+    Local --> Artifact["PNG, SVG, heatmap, JSON"]
+    Result --> Session["Continue reasoning and acting"]
+    Artifact --> Session
+```
 
-Runtime readiness is profile-wide, but the ten visual execution schemas are Agent-scoped. Before an Agent loads `vision-tools`, the plugin contributes only the small `vision_toolkit_activate` bootstrap; the visual tools are absent from that Agent's request schema. A successful call to the standard `skill` tool with `name="vision-tools"` mounts all ten tools automatically for the next model step and hides the bootstrap. A direct `/vision-tools` invocation injects the Skill instructions; if the visual tools are still absent, those instructions require one `vision_toolkit_activate` call. Activation affects only that Agent, restores when the Session contains durable evidence matching the bundled Skill version, and lasts until the Agent or plugin is disposed.
+The visual capabilities come from a packaged, pinned `agent-vision-toolkit` snapshot. The DSH plugin handles installation, session-scoped tool exposure, Credentials, path checks, cancellation, timeouts, result files, and Web presentation. The runtime never fetches upstream `main` in the background.
 
-Health checks, connection testing, and plugin/upstream version inspection are administrative Web Settings operations. `vision_toolkit_health` and `vision_toolkit_version` are not model tools and never enter an Agent's schema, including after visual-tool activation.
-
-## Image-input variants for text-only models
-
-Text-only model routes get sibling model-selector entries named `<model> (Vision Toolkit)` under a matching provider group. DSH cannot pass a pasted attachment's local path through its native image block, so every bridge path materializes the image inside the session workspace and exposes its absolute path to the model. The model can then call `vision_glance` (or another visual tool) with that path. When the server-side image-input variant is active, the same model-visible block also contains the focus-hinted `[vision model description]` evidence aligned with `agent-vision-toolkit`; the path remains available for a second, more targeted visual call. The session log contains the durable path reference and the UI keeps the paste record.
-
-A variant is registered automatically for every model the host positively declares text-only (for example the DeepSeek chat family). With the default `autoSwitch: true`, the browser switches to `<model> (Vision Toolkit)` and the server-side bridge rewrites each native image block into **both** the workspace path and the focus-hinted description; the path is not hidden from the model. Setting `autoSwitch: false` keeps the older path-only takeover instead. The host's verdict uses the exact model route the browser read from the live model catalog, with the selector label as fallback; unconfirmed or image-capable routes keep their native flow.
-
-Description conversion needs the configured vision provider and its credential when the opt-in image-input variant is used; when the runtime is not ready or a read fails, the wire block keeps the workspace path and adds the upstream-compatible `[vision unavailable: ...]` note instead of failing the turn. The bridge does not treat injected context files as the current user intent, and it uses the latest assistant paragraph when a tool-fetched image is being described. Disable variants with `imageInputVariants.enabled: false`, restrict the wrapped routes with `imageInputVariants.providers`, or opt into native attachment switching with `imageInputVariants.autoSwitch: true`.
+For routes that DSH positively identifies as text-only, the plugin registers a sibling `<model> (Vision Toolkit)` variant. By default, pasting an image in DSH Web switches to that variant and gives the model both a reusable workspace path and a visual description focused on the current task.
 
 </details>
 
-## Requirements
+## Configuration and limits
 
-- DeepSeek Harness with a Web or Headless profile and `pnpm` available to `dsh plugin`.
-- Python 3.11 or newer. Managed mode creates an isolated environment, so users do not install the upstream CLI or Python packages manually.
-- Network access on the first managed-runtime activation unless the exact packages in `runtime/requirements.lock` are already available in the configured package cache.
-- The built-in free Gemma 4 provider is ready for `vision_glance`, `vision_ground`, `vision_detect`, and non-split-only long-screenshot OCR. A DSH Credential is required only when a custom OpenAI-compatible or Anthropic endpoint is configured. Local tools remain usable without either provider.
-- Chrome, Chromium, or Edge only for `vision_html_screenshot`; all other tools remain available when no supported browser is installed.
-- PNG, JPEG, GIF, or WebP inputs inside the session workspace or an explicitly configured `allowedDirs` root.
+### Built-in free service
 
-## Install and lifecycle
+The default setup uses:
 
-### Install
-
-Install the bundle into each profile that should expose it:
-
-```sh
-dsh plugin --profile web add @anionex/dsh-vision-toolkit
-dsh plugin --profile headless add @anionex/dsh-vision-toolkit
-dsh --profile web --dump-config | grep vision-toolkit
-dsh --profile headless --dump-config | grep vision-toolkit
+```text
+Base URL: https://vision.anionex.me/v1
+Model:    gemma-4-26b-a4b-it
+API Key:  no user configuration required
 ```
 
-Restart a long-lived Web profile after installation. The host discovers the built browser bundle from `package.json`'s `dsh.client` declaration at process startup; the legacy top-level `dshClient` field is not scanned.
+This is a shared zero-configuration entry point, not an unlimited private endpoint. Current limits are:
 
-The first managed start verifies the packaged upstream manifest and atomically prepares an isolated environment under `DSH_HOME/cache/dsh-vision-toolkit`. Only after preparation succeeds does the plugin publish the same-version `vision-tools` Skill and activation bootstrap; each Agent receives the execution tools only after loading that Skill. An initial preparation failure leaves the Web Settings repair surface available but exposes neither model capability nor a misleading Skill.
+| Limit | Current value |
+|---|---:|
+| Per client | 100 requests per UTC day |
+| Whole service | 400 requests per UTC day |
+| Burst | 20 requests per 60 seconds |
+| Image size | 4 MiB per image |
+| Decoded pixels | 20,000,000 per image |
+| Output | 512 tokens per request |
 
-### Disable and re-enable
+The limits protect shared capacity and prevent unusually large images from monopolizing memory or request time. When a limit is reached, the service returns a readable reason and error code. Rate-limit responses also include `Retry-After` instead of collapsing into an unexplained model failure.
 
-Set the bundle row to `disabled: true` in a profile patch or overlay:
+### Bring your own vision model
+
+For higher quotas, private endpoints, or another model, change the provider in **Settings → Vision Toolkit** and store the API key as a DSH Credential. Settings stores the Credential reference and never reads the saved secret back into the browser.
+
+You can also configure a Profile patch:
+
+```yaml
+- id: vision-toolkit
+  config:
+    provider:
+      baseUrl: https://api.example.com/v1
+      credential: MY_VISION_KEY
+      model: your-vision-model
+      protocol: openai
+```
+
+OpenAI Chat Completions-compatible endpoints and Anthropic Messages are supported. The Web Settings panel exposes the full provider, runtime, timeout, image-limit, and image-input-variant configuration.
+
+### Requirements
+
+- A DeepSeek Harness Web or Headless Profile.
+- Node.js `^22.19.0` or `>=24.0.0`.
+- Python 3.11+; the plugin prepares an isolated environment by default.
+- Only `vision_html_screenshot` requires Chrome, Chromium, or Edge.
+- Inputs must be PNG, JPEG, GIF, or WebP files in the session workspace or an explicitly allowed directory.
+
+<details>
+<summary><strong>Install, upgrade, disable, and uninstall</strong></summary>
+
+```sh
+dsh plugin --profile web update @anionex/dsh-vision-toolkit
+dsh plugin --profile web remove @anionex/dsh-vision-toolkit
+```
+
+If you are migrating from the retired `@dsh-external/dsh-vision-toolkit`, remove the old package first and install `@anionex/dsh-vision-toolkit`.
+
+To disable the bundle temporarily, set this in the Profile patch:
 
 ```yaml
 - id: vision-toolkit
   disabled: true
 ```
 
-Remove the flag or set it to `false` to re-enable the plugin. Disposal first cancels plugin-owned visual operations, then removes every Agent-scoped tool, the bootstrap, and the Skill; reactivation prepares the configured runtime before any model capability becomes visible. User configuration and completed Artifacts remain intact.
+Restart the Web Profile and refresh the page after enabling or upgrading the Web plugin.
 
-### Upgrade
-
-**Migrating from the retired `@dsh-external/dsh-vision-toolkit`:** the npm package now lives under the `@anionex` scope. If you installed the retired package, do **not** run `update` on it — that account cannot publish this release. Migrate to the new package name and restart the Web profile:
-
-```sh
-dsh plugin --profile web remove @dsh-external/dsh-vision-toolkit
-dsh plugin --profile web add @anionex/dsh-vision-toolkit
-```
-
-After restarting, Settings → Vision should report plugin version **0.1.12**. The built-in free provider is selected automatically; custom providers still use the configured DSH Credential.
-
-For a registry installation, update the dependency through the profile package manager:
-
-```sh
-dsh plugin --profile web update @anionex/dsh-vision-toolkit
-dsh plugin --profile headless update @anionex/dsh-vision-toolkit
-```
-
-For a local path installation, run `add` again against the replacement checkout or tarball. Settings remain in the profile's Settings provider. A candidate runtime is fully validated and prepared before it is persisted and made active; a failed or obsolete concurrent candidate cannot replace the current serving generation.
-
-### Uninstall
-
-```sh
-dsh plugin --profile web remove @anionex/dsh-vision-toolkit
-dsh plugin --profile headless remove @anionex/dsh-vision-toolkit
-```
-
-`dsh plugin remove` removes both the dependency and its bundle layer. The profile no longer exposes the activation bootstrap, Agent-scoped Vision Toolkit tools, or Skill entries. Managed cache data may be deleted separately when no profile uses the package; it is not active configuration and cannot register anything by itself.
-
-## Configure
-
-The bundle defaults to the managed runtime. A profile patch can override the provider and limits:
-
-```yaml
-- id: vision-toolkit
-  config:
-    provider:
-      baseUrl: https://vision.anionex.me/v1
-      credential: ANIONEX_FREE_VISION
-      model: gemma-4-26b-a4b-it
-      protocol: openai
-      anthropicThinking: omit
-      userAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36
-    language: zh
-    timeoutMs: 60000
-    maxImageBytes: 4194304
-    maxImagePixels: 20000000
-    concurrency: 4
-    runtime:
-      mode: managed
-    allowedDirs: []
-    imageInputVariants:
-      enabled: true
-      providers: []
-      autoSwitch: true
-```
-
-### Configuration fields
-
-| Field | Default | Contract |
-|---|---|---|
-| `provider.baseUrl` | `https://vision.anionex.me/v1` | Built-in free OpenAI-compatible endpoint; custom providers may use another base URL, normalized without trailing slashes |
-| `provider.credential` | `ANIONEX_FREE_VISION` | Read-only built-in reference for the free service; custom providers use a DSH Credential reference, never a secret value |
-| `provider.model` | `gemma-4-26b-a4b-it` | Multimodal model name sent to remote tools |
-| `provider.protocol` | `openai` | `openai` sends Chat Completions requests; `anthropic` sends native Messages requests |
-| `provider.anthropicThinking` | `omit` | Anthropic thinking field. `omit` sends no thinking field and has the broadest compatibility. Use `disabled` or `adaptive` only when the selected model documents that mode; restore `omit` first if the provider returns HTTP 400. |
-| `provider.userAgent` | browser-compatible default | User-Agent sent by vision requests and explicit connection tests; override it for provider or proxy compatibility |
-| `language` | `zh` | Vision output language: `zh` or `en` |
-| `timeoutMs` | `60000` | Whole-operation deadline, 1000-600000 ms; each tool may request a narrower override |
-| `maxImageBytes` | `4194304` | Encoded-byte limit per input image; the built-in free service accepts up to 4 MiB |
-| `maxImagePixels` | `20000000` | Decoded-pixel limit per input image; the built-in free service accepts up to 20,000,000 pixels |
-| `concurrency` | `4` | In-flight operations per session, 1-16 |
-| `runtime.mode` | `managed` | `managed` uses the packaged snapshot; `external` accepts only the exact pin |
-| `runtime.agentVisionToolkitPath` | unset | Required in `external` mode; exported exact snapshot or clean pinned Git checkout |
-| `runtime.python` | unset | Optional Python 3.11+ bootstrap/interpreter override |
-| `allowedDirs` | `[]` | Additional realpath-resolved input roots; the session workspace is always allowed |
-| `imageInputVariants.enabled` | `true` | Register image-input variant entries for text-only model routes in the model selector |
-| `imageInputVariants.providers` | `[]` | Restrict wrapped upstream routes by provider id; empty wraps every eligible route |
-| `imageInputVariants.autoSwitch` | `true` | Automatically switch a text-only session to its image-input variant; the model receives both the workspace path and focused description. `false` keeps the path-only takeover |
-
-### Credentials
-
-The built-in free provider uses the fixed `ANIONEX_FREE_VISION` reference and does not accept or store a user API key. If you change the endpoint, model, or protocol to a custom provider, the write-only **API key** field unlocks; saving a non-empty value writes it under the advanced **Credential name** reference. Headless deployments can pre-provision that custom reference in `$DSH_HOME/.credentials.yaml`.
-
-Settings store only the reference, never the value. The browser does not receive a stored value, and a successful save clears the field instead of echoing it. Remote operations resolve the reference once per call and inject the value only into that subprocess environment. The plugin excludes user `.env` files, checkout `.env` files, `PYTHONPATH`, `PYTHONHOME`, `VIRTUAL_ENV`, and user site-packages so ambient Python or upstream configuration cannot override the selected DSH provider. Logs, errors, tool results, Artifact metadata, and Settings responses never contain the secret.
-
-### Built-in free service limits
-
-The public service is shared and intended as a zero-configuration default, not an unlimited private endpoint. Limits are enforced by the proxy and returned as OpenAI-style errors with a reason code and readable message; rate-limit responses also include `Retry-After` and request-quota headers.
-
-| Limit | Current value |
-|---|---:|
-| Per client | 100 requests per UTC day |
-| Global service | 400 requests per UTC day |
-| Burst | 20 requests per 60 seconds |
-| Image bytes | 4 MiB per image |
-| Decoded pixels | 20,000,000 per image |
-| Output | 512 tokens maximum |
-
-### Managed runtime and optional external runtime
-
-Managed mode verifies `vendor/agent-vision-toolkit/UPSTREAM_MANIFEST.json`, prefers `uv`, falls back to `venv` plus pip, installs exact versions from `runtime/requirements.lock`, coordinates concurrent preparation with a heartbeat lock, and publishes a staged environment only after all probes pass.
-
-Most users should stop at managed mode. It is included in the npm package and prepares the pinned Python environment for you.
-
-The optional external mode is for plugin development or controlled deployments that already maintain the exact upstream checkout:
-
-```yaml
-- id: vision-toolkit
-  config:
-    runtime:
-      mode: external
-      agentVisionToolkitPath: /opt/agent-vision-toolkit
-      python: python3.12
-```
-
-The path must be an exported copy matching the packaged manifest or the root of a clean Git checkout at `bc9803d7d6300c864d17460ecbb33540b26638e0`. Modified tracked files and untracked files are rejected because they can change or shadow the pinned Python behavior.
-
-## Web Settings
-
-The Web profile registers a Vision Toolkit Settings section for the provider URL, Credential reference, model, OpenAI/Anthropic protocol, Anthropic thinking mode, User-Agent, language, timeout, byte/pixel limits, concurrency, runtime mode, Python override, external source path, and allowed directories. It also shows plugin/upstream versions, the active runtime generation, non-secret Credential configured/source/writable facts, runtime paths, health results, and Artifact-route availability.
-
-The **Plugin updates** card checks the profile's configured npm registry for a newer `@anionex/dsh-vision-toolkit` release. **Update and restart** installs that exact confirmed version into the current DSH profile, verifies the installed package, starts an independent restart helper, and gracefully restarts DSH Web; the open page waits for the replacement process and reloads after the new plugin version is serving. The action is same-origin, fixed to this package, serialized, and unavailable for `link:`, `file:`, workspace, git, URL, transitive, ambiguous, read-only, or missing-`pnpm` installations so local development sources are never overwritten. A restart can interrupt work that is currently running, so the UI requires an explicit confirmation.
-
-`Save and apply` validates the complete value, prepares the candidate Python/upstream runtime, commits the Settings revision, and only then atomically switches generations. A rejected candidate leaves the previous generation serving and is reported separately from a genuinely unavailable runtime. `Reload` always restores the authoritative saved value, even when its revision did not change, so a rejected browser draft is discarded. If initial startup cannot prepare a runtime, the Settings route remains available so a valid configuration can make the first generation operational. A stale browser revision receives a conflict instead of overwriting a newer save; reload before retrying. A read-only Settings provider allows inspection and health checks but disables saves.
-
-`Run health check` performs local checks only. `Test API connection` is an explicit action that sends the configured Credential to `GET /models`; OpenAI uses Bearer authentication, while Anthropic uses `x-api-key` and `anthropic-version`. That lightweight probe uploads no image and creates no completion. `Test vision model` separately sends the bundled `assets/vision-model-test.png` through the same multimodal runtime path as `vision_glance`; it creates one real completion and is the authoritative check that the selected endpoint, credential, model, protocol, and upstream account can process images. The Vision model health card displays a dedicated `Verified`, `Not tested`, or `Test failed` tag, so an HTTP 200 response from `/models` is not presented as a successful image test. Plugin load and ordinary Settings reads never make either request.
-
-Health, connection testing, and plugin/upstream version inspection are administrative Web Settings capabilities rather than model-facing tools, so their schemas never occupy an agent request.
-
-## Artifacts and presentation
-
-Artifact-producing tools write only under `<workspace>/.dsh-vision-toolkit/artifacts`, either as one validated file or an atomically committed run directory. Each model-visible descriptor contains the path, filename, MIME type, kind, description, source tool, preview intent, and byte size, so Headless agents can reuse the path in later calls without browser support. Before a traced SVG is committed, the runtime parses it as XML: standard declarations and comments are accepted, while doctypes, malformed or multi-root documents, a non-SVG namespace, and reported path/byte mismatches are rejected.
-
-When the Web HTTP host is present, presentation-only metadata adds signed capability URLs for preview and download without altering the canonical tool result. Every read revalidates the signature, managed-root fence, path components, regular-file status, size, device/inode identity where available, extension, and MIME. SVG responses use a sandboxed no-resource CSP and the client renders them in a sandboxed iframe. Without an HTTP host, the same cards retain `Open file` through `openFile` and show the descriptor instead of inventing an inaccessible URL.
-
-## Usage patterns
-
-### Basic calls
-
-```text
-vision_glance images=["screenshot.png"] query="What error is shown?"
-vision_ground image="screenshot.png" target="the send button" preview=true
-vision_detect image="screenshot.png" category="buttons" preview=true
-vision_crop image="screenshot.png" region="1067,841,1108,881"
-vision_trace image="icon.png" color=true output="icon.svg"
-vision_pixel_diff original="reference.png" rebuilt="actual.png" runName="comparison"
-vision_long_screenshot_ocr image="page.png" mode="general" jobs=2
-vision_extract_foreground image="logo.png" mode="color"
-vision_dominant_colors image="screen.png" region="0,0,600,300" top=8
-vision_html_screenshot source="implementation.html" width=1200 height=720
-```
-
-Common workflows are `vision_ground` → `vision_crop` → `vision_glance`, `vision_ground` → `vision_crop` → `vision_trace`, and reference image → `vision_html_screenshot` → `vision_pixel_diff`. Grounding and detection boxes always use original-image pixels (`x1/y1/x2/y2`).
-
-### UI restoration example
-
-The checked-in [UI restoration example](examples/ui-restoration/README.md) renders a reference, an intentionally inaccurate first implementation, and the final implementation through `vision_html_screenshot`, then compares both candidates through `vision_pixel_diff`:
-
-```sh
-npm run example:ui-restoration
-npm run example:ui-restoration:write
-```
-
-The committed evidence records an initial `6.04%` difference across six non-zero worst regions and a final `0%` difference with no non-zero worst region. Check mode reproduces the tool path and verifies the committed assets; write mode intentionally refreshes the evidence.
+</details>
 
 ## Troubleshooting
 
-| Symptom | Resolution |
+| Problem | What to do |
 |---|---|
-| `Model "..." does not support image input. (attachment-error)` | The image used DSH's native model-attachment channel, so a text-only model rejected the turn before the Skill or Vision Toolkit could run. With image-input variants enabled this is rare: pasting normally auto-switches the session to the `<model> (Vision Toolkit)` variant. If variants are disabled or auto-switch is off, use DSH Paste Input's attachment button, paste, or drop flow so the file is copied into the session workspace and represented by a path, then invoke `/vision-tools`. Restart the Web profile and reload the page after installing or upgrading either browser plugin. |
-| Credential reported missing | Paste the key into Web Settings **API key**, keep the advanced **Credential name** aligned with `provider.credential`, save, then rerun health. Headless deployments can provision the same reference in `$DSH_HOME/.credentials.yaml`. Local-only tools do not need it. |
-| Runtime preparation fails | Read the Settings runtime error, verify Python 3.11+, package-cache/network access, disk permissions, and the exact external pin. Save only after correcting the candidate; the active generation remains intact. |
-| Chrome is not found | Install Chrome, Chromium, or Edge or configure an environment where one is discoverable. Only `vision_html_screenshot` is unavailable. |
-| macOS displays a keychain dialog | Confirm the current built adapter is installed and no stale external `html_shot`/headless Chrome process is running. Current launches use a mock keychain and disposable profile; cancel the dialog rather than resetting the login keychain. |
-| Input or output path is rejected | Move the file into the session workspace or add an intentional real directory to `allowedDirs`; remove escaping symlinks. Outputs accept a filename, not an absolute or nested path. |
-| Vision service returns 401/403 | Replace the Credential value or select the correct reference and endpoint. Errors remain redacted. |
-| Vision service returns 429 | Retry after the provider's rate-limit window or lower `concurrency`. The plugin does not silently switch providers. |
-| Operation times out or is cancelled | Raise `timeoutMs` within 1000-600000 ms, reduce image/chunk work, or rerun after cancellation. The subprocess/request is stopped with the operation. |
-| Settings save reports a conflict | Reload the section to obtain the current revision, reapply the intended edit, and save again. |
-| Settings is read-only | Change the active Settings provider or edit the owning profile configuration; the plugin cannot bypass provider writability. |
-| Artifact preview is unavailable | Use `Open file` or the model-visible path. Preview/download URLs exist only while a Web HTTP route is attached. |
+| Pasting an image still says the model does not support image input | Restart the Web Profile, refresh the page, and confirm the selected route has the `(Vision Toolkit)` suffix. You can also place the image in the session workspace and invoke `/vision-tools` |
+| The free service returns 429 | Wait for the `Retry-After` interval, or switch to your own endpoint when you need stable higher volume |
+| The image exceeds a size or pixel limit | Crop or resize it first; the error identifies whether bytes or decoded pixels caused the rejection |
+| A custom Credential is missing | Enter the API key in **Settings → Vision Toolkit** and confirm the Credential name matches the provider configuration |
+| First-time runtime setup fails | Check Python 3.11+, network or package-cache access, and disk permissions, then retry the model test in Settings |
+| Chrome is not found | Install Chrome, Chromium, or Edge. Only HTML screenshot rendering is unavailable; the other tools still work |
+| An artifact cannot be previewed | Use **Open file** or the workspace path in the result. Preview URLs exist only while the Web route is available |
 
-## Development and verification
+## Project status and limitations
+
+The current release focuses on screenshot understanding, visual grounding, OCR, asset extraction, UI restoration, and pixel-level verification. It is not a video, audio, or camera-input system and does not automatically click GUI controls. Interactive box editing, remote service clusters, model voting, and cross-session visual caches are also outside the current scope.
+
+## Development and community
 
 ```sh
 pnpm install --frozen-lockfile --trust-lockfile
 pnpm run verify:portable
 pnpm run build
 pnpm test
-pnpm run example:ui-restoration
-pnpm pack --dry-run
+TSX_TSCONFIG_PATH=tsconfig.json pnpm dlx tsx scripts/ui-restoration-example.ts --check
 ```
 
-`pnpm run verify:portable` is the dependency-free portable verification gate: it validates the vendored snapshot, package metadata and exports, committed JavaScript syntax, README links and images, required facade files, social-preview dimensions, and the dry-run tarball. The full TypeScript build and test suite run from this standalone checkout against the locked DSH `0.1.0-rc.6` registry packages; the client build also has a separate compiler face that resolves the packages' public exports without internal path aliases. The real Profile acceptance runs when compatible `dsh` and `pnpm` commands are on PATH, and CI requires that path instead of silently skipping it.
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) before contributing.
+- Use [GitHub Issues](https://github.com/Anionex/dsh-vision-toolkit/issues) for bugs, focused feature requests, and usage questions; see [SUPPORT.md](SUPPORT.md) for channel guidance.
+- Report vulnerabilities privately through [SECURITY.md](SECURITY.md).
+- See [CHANGELOG.md](CHANGELOG.md) for releases and [FUNDING.md](FUNDING.md) for sponsorship details.
+- Visit upstream [agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) for the general toolkit, cross-agent integrations, and visual-task playbooks.
 
-`pnpm run build` verifies the vendored manifest before emitting JavaScript, declarations, and the loader-compatible Web client. The package commits `lib/`, so installation from a checkout does not require a consumer-side build. The keyless real-profile test installs into a clean `DSH_HOME`, boots Headless, executes all five P0 tools plus representative P1 local/remote tools through real tool calls, verifies disable and re-enable behavior, and uninstalls the bundle. See the [requirements traceability reference](docs/requirements-traceability/README.md) for the implementation and verification home of every P0/P1 requirement.
+<p align="center">
+  <img src="assets/community-group-qr.png" alt="QR code for the agent-vision-toolkit community group" width="240" />
+</p>
 
-Update the upstream snapshot only through `pnpm run upstream:sync -- <checkout>`, inspect the source and license, regenerate the manifest, and update the adapter compatibility tests and committed `lib/` in the same change. The runtime never fetches upstream `main`.
-
-## Project status and scope
-
-Version `0.1.12` is the current public npm release. The product focuses on screenshot understanding, visual grounding, OCR, asset extraction, UI restoration, and pixel-level verification in DSH Web and Headless profiles. Web upload, drag-and-drop, camera/video/audio/document ingestion, interactive box editing, automatic GUI clicking, service clusters, model routing, model voting, and cross-session vision caches remain outside the current product.
-
-<details>
-<summary><strong>Maintainer scope note</strong></summary>
-
-The stable `ctx.visionToolkit` service and capability-discovery API remain unpublished until an independent plugin becomes a real consumer. This keeps the public integration surface tied to a tested use case rather than an unvalidated ecosystem contract.
-
-</details>
-
-## Community and About
-
-- Read [CONTRIBUTING.md](CONTRIBUTING.md) before proposing code, protocol, or upstream-snapshot changes.
-- Use [GitHub Issues](https://github.com/Anionex/dsh-vision-toolkit/issues) for reproducible bugs, focused feature requests, and usage questions; use [SUPPORT.md](SUPPORT.md) to choose the right channel.
-- Report vulnerabilities privately through the process in [SECURITY.md](SECURITY.md), never in a public issue.
-- Follow releases and compatibility notes in [CHANGELOG.md](CHANGELOG.md).
-- Optional sponsorship is described transparently in [FUNDING.md](FUNDING.md); support does not purchase roadmap priority or private support.
-- Use the upstream [project website](https://agent-vision.anionex.me) and [repository](https://github.com/Anionex/agent-vision-toolkit) for the general toolkit, cross-harness integrations, visual-task playbooks, and reference runs.
-- Star, share, contribute to, or sponsor `agent-vision-toolkit` if its algorithms or methods save time; DSH-specific bugs and integration requests belong in this repository.
-
-[`agent-vision-toolkit`](https://github.com/Anionex/agent-vision-toolkit) was created by [Anionex](https://anionex.me/). This repository maintains its native DeepSeek Harness integration: DSH owns lifecycle, security, structured schemas, Credentials, Artifacts, and Web presentation, while the upstream project remains the home of the visual algorithms and reusable playbooks.
-
-If you would like to follow my future work, [follow me on X](https://x.com/anion_ex) or [GitHub](https://github.com/Anionex).
+[`agent-vision-toolkit`](https://github.com/Anionex/agent-vision-toolkit) was created by [Anionex](https://anionex.me/). This repository maintains its native DeepSeek Harness integration.
 
 ## License
 
-The plugin is MIT-licensed. The packaged `agent-vision-toolkit` snapshot retains its upstream MIT license in `vendor/agent-vision-toolkit/LICENSE` and remains the sole implementation of its visual algorithms.
+The plugin is available under the [MIT License](LICENSE). The packaged upstream snapshot retains its original MIT license in [`vendor/agent-vision-toolkit/LICENSE`](vendor/agent-vision-toolkit/LICENSE).

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,484 +1,311 @@
 <p align="center">
-  <img src="assets/hero-v2.png" alt="DSH Vision Toolkit——面向纯文本 DeepSeek Harness Agent 的原生视觉工程能力" />
+  <img src="assets/hero-v2.png" alt="DSH Vision Toolkit：让纯文本 DeepSeek Harness Agent 看懂图片并完成视觉任务" />
 </p>
 
-<h1 align="center">DSH Vision Toolkit</h1>
+<div align="center">
 
-<p align="center">
-  <a href="https://github.com/Anionex/dsh-vision-toolkit/blob/main/README.md">English</a> | 中文
-</p>
+# DSH Vision Toolkit
 
-<p align="center">
-  <a href="https://dshfind.com/zh/plugins/Anionex/dsh-vision-toolkit"><img src="https://img.shields.io/badge/%E7%94%B1%20dshfind-%E6%8E%A8%E8%8D%90-FFD700?style=flat-square" alt="由 dshfind 推荐" /></a>
-  <a href="https://dshfind.com/zh/plugins/Anionex/dsh-vision-toolkit"><img src="https://img.shields.io/badge/dshfind%20%E8%AF%84%E5%88%86-94%20%7C%20%E6%9C%80%E9%AB%98%E5%88%86%E6%8F%92%E4%BB%B6-5B4CF0?style=flat-square" alt="dshfind 评分：94——最高分插件" /></a>
-  <a href="https://x.com/anion_ex"><img src="https://img.shields.io/badge/-@anion__ex-000000?style=flat-square&amp;logo=x&amp;logoColor=white" alt="X：@anion_ex" /></a>
-  <a href="https://github.com/Anionex/dsh-vision-toolkit/releases/tag/v0.1.12"><img src="https://img.shields.io/badge/release-v0.1.12-5B4CF0?style=flat-square" alt="Release v0.1.12" /></a>
-  <a href="tests"><img src="https://img.shields.io/badge/verified-233%20tests-2EA44F?style=flat-square" alt="已验证：233 项测试" /></a>
-</p>
+[![由 dshfind 推荐](https://img.shields.io/badge/%E7%94%B1%20dshfind-%E6%8E%A8%E8%8D%90-FFD700?style=flat-square)](https://dshfind.com/zh/plugins/Anionex/dsh-vision-toolkit)
+[![npm](https://img.shields.io/npm/v/@anionex/dsh-vision-toolkit?style=flat-square&color=5B4CF0)](https://www.npmjs.com/package/@anionex/dsh-vision-toolkit)
+[![MIT](https://img.shields.io/badge/license-MIT-0B7285?style=flat-square)](LICENSE)
+[![DSH](https://img.shields.io/badge/DSH-Web%20%2B%20Headless-5B4CF0?style=flat-square)](cordis.patch.yml)
 
-<p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-0B7285?style=flat-square" alt="许可证：MIT" /></a>
-  <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%5E22.19%20%7C%20%3E%3D24-339933?style=flat-square&amp;logo=nodedotjs&amp;logoColor=white" alt="Node.js ^22.19 或 >=24" /></a>
-  <a href="runtime/requirements.lock"><img src="https://img.shields.io/badge/Python-3.11%2B-3776AB?style=flat-square&amp;logo=python&amp;logoColor=white" alt="Python 3.11+" /></a>
-  <a href="cordis.patch.yml"><img src="https://img.shields.io/badge/DSH-Web%20%2B%20Headless-5B4CF0?style=flat-square" alt="DSH Web 与 Headless Profile" /></a>
-</p>
+**给 DSH 里的纯文本 Agent 装上眼睛：粘贴图片就能问，找到元素就能继续操作，还能把 UI 还原做到有数据可验。**
 
-## 让 DSH Agent 真正看见
+🌐 [English](README.md) ｜ **中文**
 
-把截图交给纯文本 DeepSeek Harness Agent，它就能看懂画面、读取文字、定位元素、提取素材、还原界面，并用像素差异检查结果是否准确。
+</div>
 
-DSH Vision Toolkit 将 [`agent-vision-toolkit`](https://github.com/Anionex/agent-vision-toolkit) 打包成原生 DSH 插件。安装后即可使用图片问答、OCR、原图像素坐标、UI 还原、像素对比、可下载产物和 Web 设置，无需自己拼接脚本。
+如果你在 DeepSeek Harness（DSH）里使用 DeepSeek 等纯文本模型，可能已经遇到过这些问题：模型看不到截图、只能得到一段泛泛的图片描述、找不到按钮的准确位置，或者还原出来的页面“看起来差不多”，却不知道到底差了多少。
+
+DSH Vision Toolkit 把 [`agent-vision-toolkit`](https://github.com/Anionex/agent-vision-toolkit) 变成一个原生 DSH 插件。安装后，Agent 不只会“看图”，还会围绕当前任务读取、定位、裁剪、描摹、还原和验证图片。
+
+> **安装即可使用。** 默认接入内置免费 Gemma 4 视觉服务，不需要申请 API Key；裁图、像素对比、颜色分析、前景提取、SVG 描摹和网页截图等本地工具也不消耗视觉 API 请求。
 
 ```sh
 dsh plugin --profile web add @anionex/dsh-vision-toolkit
 ```
-
-npm 包已经包含视觉工具快照，并默认使用托管运行时。**普通安装不需要下载源码，也不需要填写 `agentVisionToolkitPath`。**
 
 **上游工具箱：** [Anionex/agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) · **项目网站：** [agent-vision.anionex.me](https://agent-vision.anionex.me)
 
-## 你可以用它做什么
+<details>
+<summary><strong>目录</strong></summary>
 
-| 目标 | Agent 可以交付什么 |
+- [最近更新](#最近更新)
+- [它解决什么问题](#它解决什么问题)
+- [实际效果](#实际效果)
+- [亮点](#亮点)
+- [快速开始：三步完成](#快速开始三步完成)
+- [常见任务](#常见任务)
+- [工具一览](#工具一览)
+- [配置与限制](#配置与限制)
+- [常见问题](#常见问题)
+- [开发与社区](#开发与社区)
+
+</details>
+
+## 最近更新
+
+- **2026-08-16 · Windows Python：** 支持 Microsoft Store Python，解决部分 Windows 用户首次创建隔离环境失败的问题。
+- **2026-08-16 · 免费视觉升级：** 默认模型切换到 Gemma 4，解决免 Key 方案看图效果不足的问题。
+- **2026-08-16 · 图片粘贴：** 文本模型自动切换到 `(Vision Toolkit)` 变体并保留工作区路径，解决粘贴图片被拦截或后续无法复用的问题。
+- **2026-08-16 · 免费额度：** 单客户端、全局和突发额度分别提高到 `100/日`、`400/日` 和 `20/分钟`，解决早期用户容易撞限而共享额度闲置的问题。
+- **2026-08-16 · 真实模型测试：** Settings 新增完整图片请求测试，解决 `/models` 可访问却不能证明模型真的会看图的问题。
+
+## 它解决什么问题
+
+| 你遇到的问题 | Vision Toolkit 给出的结果 |
 |---|---|
-| 看懂截图 | 针对问题作答、描述画面、比较多张图片或执行 OCR |
-| 找到界面元素 | 返回原图像素坐标，并可生成带框预览图 |
-| 按参考图还原页面 | 渲染网页截图、逐区域诊断差异并持续迭代 |
-| 提取可复用素材 | 裁剪图片、透明前景、主色板或可编辑 SVG |
-| 读取长截图 | 可审计分块、Markdown、manifest 和可恢复 OCR 运行目录 |
-| 验证视觉结果 | 差异百分比、主要偏差区域、热力图和 JSON 报告 |
+| **纯文本模型看不到截图** | 在 DSH Web 中直接粘贴图片；插件会把图片交给视觉模型，再把与当前问题相关的证据交回文本模型 |
+| **图片描述很多，但没有重点** | 问“报错在哪里”“提交按钮是什么颜色”，得到围绕当前任务的回答，而不是通用看图作文 |
+| **知道有按钮，却不知道在哪** | 返回原图像素坐标，并可生成带框或带编号的预览图 |
+| **长截图 OCR 容易漏行、重复** | 分块读取并保留 Markdown、分块图、清单和审计结果，失败后也能继续 |
+| **UI 还原只能凭感觉调** | 把参考图和实现截图做像素对比，给出差异比例、重点区域、热力图和 JSON 报告 |
+| **截图里的素材无法继续使用** | 直接得到裁剪图、透明 PNG、主色板或可编辑 SVG，而不只是一段文字 |
 
-只有需要理解图片内容时才调用远程视觉模型。裁剪、描摹、像素对比、颜色分析、前景提取和 HTML 截图都在本地运行。
+## 实际效果
 
-## 看看实际效果
-
-第一个示例是 DSH Web 的真实界面视图；接下来两组示例来自本插件所打包的同一条 `agent-vision-toolkit` 代码线；最后一组展示 DeepSeek Harness Web 中的真实使用流程。素材来源见[素材溯源记录](assets/upstream/README.md)。
-
-### DSH 视图示例
+### 在 DSH 里直接粘贴图片提问
 
 <p align="center">
-  <img src="assets/dsh-view-example.png" width="80%" alt="DSH Web 会话视图：纯文本的 DeepSeek-V4-Flash (Vision Toolkit) 模型回答用户粘贴的品牌横幅图内容。" />
+  <img src="assets/dsh-view-example.png" width="82%" alt="DSH Web 中，纯文本 DeepSeek 模型通过 Vision Toolkit 回答用户粘贴图片里的内容" />
 </p>
 
-*真实的 DSH Web 视图：用户粘贴一张品牌横幅截图，纯文本模型通过 `DeepSeek-V4-Flash (Vision Toolkit)` 图片输入变体回答图片内容。*
+*用户粘贴一张图片，纯文本模型自动切换到对应的 `Vision Toolkit` 变体，并围绕用户的问题读取画面。*
 
-### 信息图还原：从截图到可编辑 HTML/CSS
+### 从截图到可编辑页面
 
 <p align="center">
-  <img src="assets/upstream/infographic-reference.webp" width="49%" alt="上游用于还原的三阶段模型训练信息图原始截图。" />
-  <img src="assets/upstream/infographic-result.webp" width="49%" alt="上游使用 HTML 和 CSS 还原出的可编辑模型训练信息图。" />
+  <img src="assets/upstream/infographic-reference.webp" width="49%" alt="用于还原的信息图原始截图" />
+  <img src="assets/upstream/infographic-result.webp" width="49%" alt="根据截图还原出的可编辑 HTML 和 CSS 页面" />
 </p>
 
-*左：原始截图；右：上游[信息图还原示例](https://github.com/Anionex/agent-vision-toolkit/blob/c27d1a300962b553c0884993c575cd3e819465ce/examples/infographic-restoration/how-is-the-model-trained.html)生成的可编辑 HTML/CSS 结果。*
+*左：参考截图；右：用 HTML/CSS 还原出的可编辑结果。视觉结果可以继续进入截图和像素对比流程，而不是停在“描述图片”。*
 
-### UI 还原：从手绘稿到可用界面
+### 从手绘稿到可用界面
 
 <p align="center">
-  <img src="assets/upstream/ui-sketch.webp" width="49%" alt="上游用于 UI 还原的手绘 JupyterLab 工作区参考图。" />
-  <img src="assets/upstream/ui-result.webp" width="49%" alt="上游依据手绘参考图还原出的 JupyterLab 风格可用界面。" />
+  <img src="assets/upstream/ui-sketch.webp" width="49%" alt="作为 UI 还原输入的手绘 JupyterLab 界面草图" />
+  <img src="assets/upstream/ui-result.webp" width="49%" alt="根据手绘参考还原出的 JupyterLab 工作区界面" />
 </p>
 
-*左：手绘输入；右：上游还原出的界面，完整方法见 [UI 还原 playbook](https://github.com/Anionex/agent-vision-toolkit/blob/c27d1a300962b553c0884993c575cd3e819465ce/skills/vision-tools/references/restore-ui.md)。*
+*左：手绘参考；右：根据参考还原的可用界面。*
 
-### 图片问答与截图辅助排障
+### 让“差不多”变成“可验证”
 
-<p align="center">
-  <img src="assets/dsh-conversation-image-qa.png" width="49%" alt="DSH Web 会话中，纯文本 Agent 针对 UI 参考图回答聚焦问题。" />
-  <img src="assets/dsh-conversation-screenshot-debugging.png" width="49%" alt="DSH Web 会话中，Agent 根据截图对比定位 UI 字段差异并建议继续运行 vision_pixel_diff。" />
-</p>
-
-*左：DSH Web 中带意图的图片问答；右：DSH Web 中通过截图对比定位 UI 字段差异，并继续向 `vision_pixel_diff` 推进。上游工作流来源仍为 [`agent-vision-toolkit` 官方实跑](https://github.com/Anionex/agent-vision-toolkit/blob/c27d1a300962b553c0884993c575cd3e819465ce/README.md#real-world-effects)。*
-
-DSH Vision Toolkit 把这套工作流带进 DSH，让结果可以直接成为文件、坐标、可度量的对比报告，或同一会话中的下一步行动。
-
-## 从大致相似到像素级一致
-
-仓库内的 UI 还原流程从一个故意不准确的 HTML 实现开始。Vision Toolkit 测得 `6.04%` 差异，指出最需要修正的区域，并推动下一轮迭代。最终渲染结果在 `1200 × 720` 下达到精确 `0%` 差异。
+仓库内置了一个可复现的 UI 还原示例：初版与参考图的差异为 **6.04%**，经过定位和修正后，在 `1200 × 720` 下达到 **0% 像素差异**。
 
 <p>
-  <img src="examples/ui-restoration/assets/initial.png" width="49%" alt="Vision Toolkit 迭代前的 UI 还原候选，与参考图仍有可测量的布局和样式差异。" />
-  <img src="examples/ui-restoration/assets/implementation.png" width="49%" alt="仓库内可复现流程生成的最终 UI 还原结果，与参考图达到零像素差异。" />
+  <img src="examples/ui-restoration/assets/initial.png" width="49%" alt="像素对比前仍有布局和样式偏差的初版 UI" />
+  <img src="examples/ui-restoration/assets/implementation.png" width="49%" alt="经过视觉定位和像素对比后达到零差异的最终 UI" />
 </p>
 
-| 起点 | 结果 |
-|---|---|
-| 参考图 | 可打开、可编辑的 HTML 实现 |
-| 第一次对比 | 主要问题区域的差异为 `6.04%` |
-| 最终对比 | 在 `1200 × 720` 下达到 `0%` 差异 |
+## 亮点
 
-## 它为什么好用
+- **安装后就能免费用。** 新用户默认使用内置 Gemma 4 服务，不需要注册新的模型平台，也不需要先填写 Key。
+- **不只描述图片，而是解决当前问题。** Agent 会把当前任务作为视觉关注点，优先返回这一轮真正要用到的内容。
+- **返回可以继续工作的结果。** 坐标、OCR、透明 PNG、SVG、截图、热力图和 JSON 都能直接交给下一步。
+- **特别适合 UI 和截图工程。** 从参考图、元素定位、素材提取到 HTML 截图和像素对比，形成完整闭环。
+- **能本地做的就本地做。** 裁剪、描摹、像素对比、颜色、前景和 HTML 截图不需要上传到视觉模型。
+- **Web 与 Headless 使用同一套能力。** Web 中可以预览和下载产物，Headless 中仍会得到可重放的结构化结果和文件路径。
 
-- **直接提出你要解决的问题。** “提交按钮在哪里？”和“这张截图为什么和参考图不一样？”都会进入针对性的视觉分析，而不是得到一段泛泛的描述。
-- **拿到可以继续使用的证据。** Agent 会返回坐标、OCR、测量结果、JSON 和文件，方便打开或交给下一步处理。
-- **工作流留在 DSH 里。** Credential、Settings、产物、Web 卡片和 Headless 结果都与会话的其他内容放在一起。
-- **能本地处理就不调用远程模型。** 裁剪、描摹、像素对比、颜色分析、前景提取和 HTML 截图都不消耗视觉 API 请求。
-- **让迭代有终点。** 参考图 → 实现 → 截图 → 像素对比，把 UI 还原变成有数据支撑的闭环。
+## 快速开始：三步完成
 
-## 三步开始使用
-
-使用 DeepSeek Harness `0.1.0-rc.6` 或兼容的后续 `0.1.x` 版本即可。插件会在第一次使用时准备托管运行时。
+### 1. 安装
 
 ```sh
 dsh plugin --profile web add @anionex/dsh-vision-toolkit
+```
+
+Headless Profile 也可以安装：
+
+```sh
 dsh plugin --profile headless add @anionex/dsh-vision-toolkit
 ```
 
-1. 重启 Web Profile，打开 **设置 → 视觉工具**。
-2. 如果要使用远程视觉模型，选择 DSH Credential，然后执行**测试 API 连接**和**测试视觉模型**。
-3. 在会话中粘贴图片或把图片放进工作区，调用 `/vision-tools`，提出一个明确的视觉任务。
+### 2. 重启并确认
 
-如果使用较旧的 DSH launcher，安装前可能需要在 Profile 中设置 `nodeLinker: hoisted` 和 `autoInstallPeers: false`。当前 launcher 会自动修复这些设置。
+重启正在运行的 Web Profile，打开 **设置 → 视觉工具**。默认免费服务已经配置好；你可以直接运行**测试视觉模型**确认连接。
 
-安装后重启正在运行的 Web Profile，打开 **设置 → 视觉工具**，先执行**测试 API 连接**，再执行**测试视觉模型**。新安装会自动使用内置免费 Gemma 4 提供方，不需要 API Key 或 DSH Credential。若要使用其他提供方，请修改端点、模型或协议，并配置对应的 DSH Credential。
+首次启动会自动准备隔离运行环境，因此需要能访问 Python 包缓存或网络。普通安装不需要下载 `agent-vision-toolkit` 源码，也不需要设置本地路径。
 
-## 加入交流群
+### 3. 粘贴图片，直接说你要做什么
 
-欢迎加入 `agent-vision-toolkit` 项目交流群，交流使用经验、反馈问题并提出建议。
+在会话中粘贴截图，或把图片放进会话工作区，然后调用 `/vision-tools`。例如：
 
-<p align="center">
-  <img src="assets/community-group-qr.png" alt="agent-vision-toolkit 项目交流群二维码" width="260">
-</p>
-本地裁剪、SVG、像素、颜色、前景和 HTML 操作不需要视觉 API Credential。
+```text
+看看这张截图，告诉我报错原因和最值得先修的地方。
+找到右上角的登录按钮，返回原图像素坐标并生成带框预览图。
+把这个图标裁出来并转成 SVG。
+按照 reference.png 还原页面，每轮截图后做像素对比，直到主要差异消失。
+```
 
-> **不需要本地路径。** 普通 npm 安装保持默认的 `runtime.mode: managed` 即可。`runtime.agentVisionToolkitPath` 只面向明确需要外部固定 checkout 的开发者或受控部署。
+## 常见任务
 
-<details>
-<summary><strong>技术架构</strong></summary>
+| 任务 | 推荐工作流 |
+|---|---|
+| 图片问答 / 截图排障 | 看图 → 围绕当前问题回答 → 必要时继续定位 |
+| 找按钮、图标或文字区域 | 定位目标 → 返回像素框 → 生成标注预览 |
+| 提取截图里的图标 | 定位 → 裁剪 → 描摹为 SVG |
+| 读取长网页截图 | 自动分块 → OCR → 合并 Markdown → 检查边界 |
+| 复刻网页或组件 | 参考图 → 实现 → HTML 截图 → 像素对比 → 继续修正 |
+| 提取品牌视觉 | 裁剪区域 → 主色分析 → 前景提取 → 导出透明 PNG |
+
+## 工具一览
+
+插件提供 10 个可以单独调用、也可以组合使用的视觉工具：
+
+| 工具 | 最适合解决的问题 | 主要结果 |
+|---|---|---|
+| `vision_glance` | “这张图里发生了什么？” | 针对性回答、描述、OCR、多图比较 |
+| `vision_ground` | “我要找的东西在哪？” | 原图像素坐标、可选带框预览 |
+| `vision_detect` | “图里有哪些按钮/图标/元素？” | 编号元素清单、坐标、可选预览 |
+| `vision_crop` | “把这块区域单独取出来” | PNG 或 JPEG 裁剪图 |
+| `vision_trace` | “把这个图形变成可编辑矢量” | SVG |
+| `vision_pixel_diff` | “实现和参考图到底差在哪？” | 差异比例、重点区域、热力图、JSON |
+| `vision_long_screenshot_ocr` | “读完这张很长的截图” | Markdown、分块图、清单和审计结果 |
+| `vision_extract_foreground` | “把主体抠出来” | 透明 PNG |
+| `vision_dominant_colors` | “这块区域用了哪些主要颜色？” | 主色板或候选色排序 |
+| `vision_html_screenshot` | “把本地页面渲染成固定尺寸截图” | PNG |
+
+坐标始终使用原图像素格式 `x1,y1,x2,y2`，因此定位结果可以直接交给裁剪、描摹或后续自动化。
 
 ## 工作原理
 
-```mermaid
-flowchart LR
-    User["Workspace image or local HTML"] --> Skill["vision-tools Skill"]
-    Skill --> Activate["Agent-scoped activation"]
-    Activate --> Tools["10 independent vision_* tools"]
-    Tools --> Runtime["Shared VisionToolkitRuntime"]
-    Credentials["DSH Credentials"] --> Runtime
-    Settings["Web Settings and health"] --> Runtime
-    Runtime --> Upstream["Pinned agent-vision-toolkit"]
-    Runtime --> Remote["Configured vision API"]
-    Upstream --> Result["Text, coordinates, JSON"]
-    Remote --> Result
-    Runtime --> Artifacts["Workspace Artifacts"]
-    Result --> Session["Reconstructable Session log"]
-    Artifacts --> Web["Preview, download, or open file"]
-```
-
-所有工具定义都调用同一个 Runtime；Runtime 在分发到固定上游快照或已配置的视觉提供方端点前，统一验证路径、限制、Credential、取消和超时。Web 展示读取相同的结构化结果与产物描述，因此不会改变 Headless 语义。健康、连接测试和版本检查只留在 Settings，不进入模型工具 schema。
-
-</details>
-
-## 工具
-
-| 工具 | 执行方式 | 结构化结果 | 产物交付 |
-|---|---|---|---|
-| `vision_glance` | 远程视觉 API | 描述、针对性回答、OCR 或多图比较 | 无 |
-| `vision_ground` | 远程视觉 API；可选本地预览 | 目标、原图尺寸和像素框 | 可选标注 PNG |
-| `vision_detect` | 远程视觉 API；可选本地预览 | 带编号的元素清单和原图像素框 | 可选编号 PNG |
-| `vision_trace` | 本地固定 vtracer 流水线 | SVG 几何状态、路径数、缩放和大小 | SVG |
-| `vision_crop` | 本地 Pillow 流水线 | 实际像素框、尺寸、格式和裁剪边界状态 | PNG 或 JPEG |
-| `vision_pixel_diff` | 本地 NumPy/Pillow 流水线 | 差异比例和排序后的网格区域 | PNG 热力图和 JSON 报告 |
-| `vision_long_screenshot_ocr` | 本地切分/审计；除 `splitOnly=true` 外执行远程 OCR | 分块边界、复用状态、完成状态和运行目录 | Markdown、manifest、边界审计、分块 PNG 和 OCR 伴随文件 |
-| `vision_extract_foreground` | 本地固定提取流水线 | 选区、连通分量数、前景覆盖率和尺寸 | 透明 PNG |
-| `vision_dominant_colors` | 本地固定颜色分析 | 提取的调色板或有像素证据的候选色排序 | 无 |
-| `vision_html_screenshot` | 本地 Chrome/Chromium/Edge 适配器 | 已授权源文件信息、视口和渲染尺寸 | PNG |
-
-插件不重新实现视觉算法。DSH 侧只负责验证路径与限制、解析 Credential、用 argv 向量调用固定上游脚本、解析精确输出契约、分类失败、描述文件，并把结果投影给模型和 Web 客户端。
+插件把远程图片理解和可重复的本地图片处理放进同一套 Agent 工作流。展开下面的流程可以查看具体边界。
 
 <details>
-<summary><strong>高级模型行为</strong></summary>
+<summary><strong>架构与图片输入行为</strong></summary>
 
-## 渐进式模型暴露
+```mermaid
+flowchart LR
+    Image["截图或本地 HTML"] --> Skill["vision-tools Skill"]
+    Skill --> Agent["文本 Agent 选择任务"]
+    Agent --> Vision["需要理解图片时调用视觉模型"]
+    Agent --> Local["裁剪、SVG、像素等任务在本地处理"]
+    Vision --> Result["回答、OCR、坐标"]
+    Local --> Artifact["PNG、SVG、热力图、JSON"]
+    Result --> Session["继续推理和行动"]
+    Artifact --> Session
+```
 
-运行时就绪状态属于整个 Profile，但 10 个视觉执行工具的 schema 属于具体 Agent。Agent 加载 `vision-tools` 前，插件只贡献很小的 `vision_toolkit_activate` 引导工具；该 Agent 的请求 schema 中没有视觉执行工具。标准 `skill` 工具以 `name="vision-tools"` 成功加载后，会为下一模型步骤自动挂载全部 10 个工具并隐藏引导工具。直接调用 `/vision-tools` 会注入 skill 指令；如果此时视觉工具仍不可见，这些指令要求调用一次 `vision_toolkit_activate`。激活只影响当前 Agent；Session 中存在与打包 skill 版本匹配的持久证据时可以恢复，并持续到 Agent 或插件被释放。
+视觉能力来自打包的固定版本 `agent-vision-toolkit`。DSH 插件负责安装、会话级工具暴露、Credential、路径校验、取消、超时、结果文件和 Web 展示。运行时不会在后台拉取上游 `main`。
 
-健康检查、连接测试以及插件/上游版本检查属于 Web Settings 管理操作。`vision_toolkit_health` 和 `vision_toolkit_version` 不是模型工具，即使视觉执行工具已经激活，也永远不会进入 Agent schema。
-
-## 纯文本模型的图片输入变体
-
-纯文本模型路由仍会获得同名的兄弟模型条目：`<模型名> (Vision Toolkit)`，挂在对应的提供方分组下。但 DSH 原生图片块不会把粘贴附件的本地路径传给模型，因此所有桥接路径都会先把图片复制进会话工作区，再把绝对路径暴露给模型。模型随后可以把这个路径传给 `vision_glance` 或其他视觉工具。当服务端图片输入变体启用时，同一个模型可见消息还会包含与 `agent-vision-toolkit` 对齐、带 focus hint 的 `[vision model description]` 证据；路径仍然保留，模型可以再次针对更具体的问题调用视觉工具。会话日志保存可复用的路径引用，UI 保留粘贴记录。
-
-插件会自动为宿主明确声明为纯文本的每个模型注册变体（例如 DeepSeek 对话家族）。粘贴处理是全自动的：当当前模型被确认为纯文本、且它的变体已注册时，浏览器端集成会自动把会话切换到变体（会有一条简短提示说明新模型名），随后粘贴走原生流程，无需手动切换模型。宿主依据浏览器从实时模型目录读到的精确模型路由来裁决，模型选择器标签作为兜底；无法确认或支持图片的路由一律保持原生流程，而"纯文本但没有变体"的模型（例如变体被关闭时）继续走"粘贴转路径"：图片被复制进会话工作区，输入框里插入的是它的路径文本。
-
-默认启用图片输入变体自动切换。描述转换需要已配置的视觉提供方及其 Credential；当运行时未就绪或读取失败时，请求链路上的图片块仍保留工作区路径，并追加与上游兼容的 `[vision unavailable: ...]` 提示，而不是让整轮失败。桥接不会把注入的上下文文件当作当前用户意图；如果图片来自工具调用，则使用最新的助手段落作为关注提示。用 `imageInputVariants.enabled: false` 关闭变体，用 `imageInputVariants.providers` 限制被包装的路由，或用 `imageInputVariants.autoSwitch: false` 改回只注入路径的接管流程。
+对于明确标记为纯文本的模型，插件会注册 `<模型名> (Vision Toolkit)` 变体。默认情况下，在 DSH Web 粘贴图片时会自动切换到该变体，并把图片路径与带当前任务重点的视觉描述一起交给模型。
 
 </details>
 
-## 运行要求
+## 配置与限制
 
-- 启用 Web 或 Headless Profile 的 DeepSeek Harness，并确保 `dsh plugin` 可以使用 `pnpm`。
-- Python 3.11 或更高版本。Managed 模式会创建隔离环境，用户无需手工安装上游 CLI（命令行界面）或 Python 包。
-- 首次启用 managed 运行时需要联网；如果配置的软件包缓存已有 `runtime/requirements.lock` 中的精确版本，则无需联网。
-- 内置免费 Gemma 4 提供方可直接用于 `vision_glance`、`vision_ground`、`vision_detect` 和非仅切分长截图 OCR。只有改用自定义 OpenAI 兼容或 Anthropic 端点时才需要 DSH Credential；本地工具不依赖任何远程提供方。
-- 只有 `vision_html_screenshot` 需要 Chrome、Chromium 或 Edge；未安装受支持浏览器时，其他工具保持可用。
-- 输入必须是会话工作区或显式 `allowedDirs` 根目录内的 PNG、JPEG、GIF 或 WebP。
+### 默认免费服务
 
-## 安装与生命周期
+默认配置使用：
 
-### 安装
-
-将 Bundle 安装到需要暴露能力的每个 Profile：
-
-```sh
-dsh plugin --profile web add @anionex/dsh-vision-toolkit
-dsh plugin --profile headless add @anionex/dsh-vision-toolkit
-dsh --profile web --dump-config | grep vision-toolkit
-dsh --profile headless --dump-config | grep vision-toolkit
+```text
+Base URL: https://vision.anionex.me/v1
+Model:    gemma-4-26b-a4b-it
+API Key:  不需要用户配置
 ```
 
-安装后需要重启长期运行的 Web Profile。宿主在进程启动时通过 `package.json` 的 `dsh.client` 声明发现已构建的浏览器 Bundle；旧的顶层 `dshClient` 字段不会被扫描。
+这是共享的免费入口，不是无限量私有服务。当前限制如下：
 
-首次 managed 启动会验证打包的上游 manifest（元数据清单），并在 `DSH_HOME/cache/dsh-vision-toolkit` 下原子准备隔离环境。插件只在准备成功后发布同版本的 `vision-tools` skill 与激活引导工具；每个 Agent 只有在加载该 skill 后才获得执行工具。初次准备失败时，Web Settings 修复入口仍然可用，但插件不会暴露任何模型能力或误导模型的 skill。
+| 限制 | 当前值 |
+|---|---:|
+| 单客户端 | 每个 UTC 日 100 次 |
+| 全局服务 | 每个 UTC 日 400 次 |
+| 突发请求 | 60 秒内 20 次 |
+| 单张图片大小 | 4 MiB |
+| 单张图片像素 | 20,000,000 |
+| 单次输出 | 512 tokens |
 
-### 禁用与重新启用
+这些限制用于保护共享额度、避免异常大图占满内存或请求时间。触发限制时，服务会返回明确的原因代码和可读提示；限流响应还会带上 `Retry-After`，不会只得到一个含糊的“模型失败”。
 
-在 Profile patch 或 overlay 中把 Bundle 行设为 `disabled: true`：
+### 使用自己的视觉模型
+
+如果你需要更高额度、私有端点或其他模型，可以在 **设置 → 视觉工具** 中修改提供方，并把 API Key 保存为 DSH Credential。Settings 只保存 Credential 引用，不会回显密钥。
+
+也可以在 Profile patch 中配置：
+
+```yaml
+- id: vision-toolkit
+  config:
+    provider:
+      baseUrl: https://api.example.com/v1
+      credential: MY_VISION_KEY
+      model: your-vision-model
+      protocol: openai
+```
+
+支持 OpenAI Chat Completions 兼容端点和 Anthropic Messages。Web Settings 页面还可以调整超时、图片限制、并发、运行时和图片输入变体。
+
+### 运行要求
+
+- DeepSeek Harness Web 或 Headless Profile。
+- Node.js `^22.19.0` 或 `>=24.0.0`。
+- Python 3.11+；插件默认自动创建隔离环境。
+- 只有 `vision_html_screenshot` 需要 Chrome、Chromium 或 Edge。
+- 图片需为 PNG、JPEG、GIF 或 WebP，并位于会话工作区或明确允许的目录中。
+
+<details>
+<summary><strong>安装、升级、禁用和卸载</strong></summary>
+
+```sh
+dsh plugin --profile web update @anionex/dsh-vision-toolkit
+dsh plugin --profile web remove @anionex/dsh-vision-toolkit
+```
+
+如果从已停止发布的 `@dsh-external/dsh-vision-toolkit` 迁移，请先移除旧包，再安装 `@anionex/dsh-vision-toolkit`。
+
+需要临时禁用时，在 Profile patch 中设置：
 
 ```yaml
 - id: vision-toolkit
   disabled: true
 ```
 
-删除该字段或设为 `false` 即可重新启用。资源释放会先取消插件拥有的视觉操作，再移除全部 Agent 级工具、引导工具和 skill；重新启用时，配置的运行时准备完成后才会暴露任何模型能力。用户配置和已完成的产物会保留。
+重新启用或升级 Web 插件后，请重启 Web Profile 并刷新页面。
 
-### 升级
+</details>
 
-**从已停用的 `@dsh-external/dsh-vision-toolkit` 迁移：** npm 包现在位于 `@anionex` 作用域。如果你安装的是已停用的旧包，**不要**对它执行 `update`——该账号无法发布本版本。请迁移到新包名并重启 Web Profile：
+## 常见问题
 
-```sh
-dsh plugin --profile web remove @dsh-external/dsh-vision-toolkit
-dsh plugin --profile web add @anionex/dsh-vision-toolkit
-```
-
-重启后，Settings → 视觉工具 应显示插件版本 **0.1.12**。内置免费提供方会自动选中；自定义提供方仍使用配置的 DSH Credential。
-
-通过注册表安装时，使用 Profile 的包管理命令更新依赖：
-
-```sh
-dsh plugin --profile web update @anionex/dsh-vision-toolkit
-dsh plugin --profile headless update @anionex/dsh-vision-toolkit
-```
-
-通过本地路径安装时，对替换后的 checkout 或 tarball 再次执行 `add`。Settings 保存在 Profile 的 Settings 提供方中。候选运行时完成验证和准备后才会持久化并启用；失败候选或已经陈旧的并发候选无法替换当前服务 generation。
-
-### 卸载
-
-```sh
-dsh plugin --profile web remove @anionex/dsh-vision-toolkit
-dsh plugin --profile headless remove @anionex/dsh-vision-toolkit
-```
-
-`dsh plugin remove` 会同时移除依赖及其 Bundle 层。Profile 随即不再暴露激活引导工具、Agent 级 Vision Toolkit 工具或 skill 条目。没有 Profile 使用本包时可以另行删除 managed 缓存；缓存不是活动配置，无法自行注册任何能力。
-
-## 配置
-
-Bundle 默认使用 managed 运行时。Profile patch 可以覆盖提供方与限制：
-
-```yaml
-- id: vision-toolkit
-  config:
-    provider:
-      baseUrl: https://vision.anionex.me/v1
-      credential: ANIONEX_FREE_VISION
-      model: gemma-4-26b-a4b-it
-      protocol: openai
-      anthropicThinking: omit
-      userAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36
-    language: zh
-    timeoutMs: 60000
-    maxImageBytes: 4194304
-    maxImagePixels: 20000000
-    concurrency: 4
-    runtime:
-      mode: managed
-    allowedDirs: []
-    imageInputVariants:
-      enabled: true
-      providers: []
-      autoSwitch: true
-```
-
-### 配置字段
-
-| 字段 | 默认值 | 契约 |
-|---|---|---|
-| `provider.baseUrl` | `https://vision.anionex.me/v1` | 内置免费 OpenAI 兼容端点；自定义提供方可改用其他基础 URL，使用时会去除结尾斜杠 |
-| `provider.credential` | `ANIONEX_FREE_VISION` | 免费服务的只读内置引用；自定义提供方使用 DSH Credential 引用，而不是密钥值 |
-| `provider.model` | `gemma-4-26b-a4b-it` | 远程工具使用的多模态模型名 |
-| `provider.protocol` | `openai` | `openai` 发送 Chat Completions 请求；`anthropic` 发送原生 Messages 请求 |
-| `provider.anthropicThinking` | `omit` | Anthropic thinking 字段。`omit` 不发送 thinking 字段，兼容性最好；仅当所选模型明确支持时使用 `disabled` 或 `adaptive`，提供方返回 HTTP 400 时应先恢复 `omit`。 |
-| `provider.userAgent` | 浏览器兼容默认值 | 视觉请求和显式连接测试发送的 User-Agent；可为提供方或代理兼容性覆盖 |
-| `language` | `zh` | 视觉输出语言：`zh` 或 `en` |
-| `timeoutMs` | `60000` | 完整操作截止时间，1000-600000 毫秒；每个工具可请求更窄的覆盖值 |
-| `maxImageBytes` | `4194304` | 每张输入图片的编码字节上限；内置免费服务最多接受 4 MiB |
-| `maxImagePixels` | `20000000` | 每张输入图片的解码像素上限；内置免费服务最多接受 20,000,000 像素 |
-| `concurrency` | `4` | 每个会话内的并发操作数，1-16 |
-| `runtime.mode` | `managed` | `managed` 使用打包快照；`external` 只接受精确固定版本 |
-| `runtime.agentVisionToolkitPath` | 未设置 | `external` 模式必填；必须是精确导出快照或固定 commit 的干净 Git checkout |
-| `runtime.python` | 未设置 | 可选的 Python 3.11+ 引导程序/解释器覆盖值 |
-| `allowedDirs` | `[]` | 额外的 realpath 解析输入根目录；会话工作区始终允许 |
-| `imageInputVariants.enabled` | `true` | 为纯文本模型路由在模型选择器中注册图片输入变体条目 |
-| `imageInputVariants.providers` | `[]` | 按提供方 id 限制被包装的上游路由；为空时包装所有符合条件的路由 |
-| `imageInputVariants.autoSwitch` | `true` | 粘贴时自动切换到图片输入变体；模型同时收到工作区路径和聚焦描述。设为 `false` 时只走路径接管 |
-
-### Credential
-
-内置免费提供方使用固定的 `ANIONEX_FREE_VISION` 引用，不接受也不会保存用户 API Key。修改端点、模型或协议切换到自定义提供方后，只写的 **API 密钥** 输入框会自动解锁；填写后保存，会把密钥写入高级设置中的 **凭据名称** 引用。Headless 部署可以在 `$DSH_HOME/.credentials.yaml` 中预置该自定义引用。
-
-Settings 只保存引用，不保存值。浏览器不会读取已保存的密钥，保存成功后输入框也会立即清空而不是回显。每次远程操作都会重新解析引用，并只把值注入对应子进程环境。插件排除用户 `.env`、checkout `.env`、`PYTHONPATH`、`PYTHONHOME`、`VIRTUAL_ENV` 和用户 site-packages，避免环境中的 Python 或上游配置覆盖选定的 DSH 提供方。日志、错误、工具结果、产物元数据和 Settings 响应都不包含密钥。
-
-### 内置免费服务限制
-
-公开服务是共享的零配置默认入口，不是无限量私有端点。限制由代理执行，并以 OpenAI 风格错误返回明确的原因代码和可读提示；限流响应还会携带 `Retry-After` 与请求额度响应头。
-
-| 限制 | 当前值 |
-|---|---:|
-| 单客户端 | 每个 UTC 日 100 次 |
-| 全局服务 | 每个 UTC 日 400 次 |
-| 突发 | 60 秒内 20 次 |
-| 图片字节 | 每张最多 4 MiB |
-| 解码像素 | 每张最多 20,000,000 像素 |
-| 输出 | 最多 512 tokens |
-
-### Managed 运行时与可选 external 运行时
-
-Managed 模式会验证 `vendor/agent-vision-toolkit/UPSTREAM_MANIFEST.json`，优先使用 `uv`，回退到 `venv` 加 pip，按 `runtime/requirements.lock` 安装精确版本，通过 heartbeat 锁协调并发准备，并只在全部探针通过后发布 staging 环境。
-
-大多数用户只需要 managed 模式。它已经包含在 npm 包中，会自动为你准备固定版本的 Python 环境。
-
-可选的 external 模式面向插件开发或受控部署，适用于已经维护好精确上游 checkout 的场景：
-
-```yaml
-- id: vision-toolkit
-  config:
-    runtime:
-      mode: external
-      agentVisionToolkitPath: /opt/agent-vision-toolkit
-      python: python3.12
-```
-
-该路径必须是与打包 manifest 一致的导出副本，或 commit `bc9803d7d6300c864d17460ecbb33540b26638e0` 的干净 Git checkout 根目录。插件拒绝已修改的 tracked 文件和 untracked 文件，因为它们可能改变或遮蔽固定 Python 行为。
-
-## Web Settings
-
-Web Profile 会注册 Vision Toolkit Settings 分区，可配置提供方 URL、Credential 引用、模型、OpenAI/Anthropic 协议、Anthropic thinking 模式、User-Agent、语言、超时、字节/像素限制、并发数、运行时模式、Python 覆盖值、external 源码路径和允许目录。该页面还会显示插件/上游版本、当前运行时 generation、不含密钥的 Credential configured/source/writable 状态、运行时路径、健康检查结果和产物路由可用性。
-
-**插件更新**卡片会通过当前 Profile 配置的 npm registry 检查 `@anionex/dsh-vision-toolkit` 新版本。点击**自动更新并重启**后，插件只安装用户刚刚确认的准确版本，校验安装结果，启动独立重启辅助进程，再优雅重启 DSH Web；当前页面会等待新进程恢复，并在新插件版本开始服务后自动刷新。该操作要求同源请求，只能更新这个固定包，并且会串行执行；`link:`、`file:`、workspace、git、URL、传递依赖、无法唯一识别、只读或缺少 `pnpm` 的安装方式不会开放自动更新，避免覆盖本地开发源码。重启可能中断正在运行的任务，因此界面会要求再次确认。
-
-“保存并应用”会验证完整配置，准备候选 Python/上游运行时，提交 Settings revision，最后才原子切换 generation。候选被拒绝时，之前的 generation 继续服务，页面也会把这种状态与运行时确实不可用区分开来。“重新加载”始终恢复后端已保存的权威值，即使 revision 没有变化也会丢弃被拒绝的浏览器草稿。初始启动无法准备运行时时，Settings 路由仍可用于提交有效配置并激活首个 generation。陈旧浏览器 revision 不会覆盖较新的保存结果，而是返回冲突；刷新后再重试。只读 Settings 提供方允许查看和健康检查，但禁用保存。
-
-“运行健康检查”只执行本地检查。“测试 API 连接”是显式操作，会把已配置 Credential 发送到 `GET /models`；OpenAI 使用 Bearer 认证，Anthropic 使用 `x-api-key` 与 `anthropic-version`。这个轻量测试不会上传图片，也不会创建 completion。“测试视觉模型”会另行把插件自带的 `assets/vision-model-test.png` 通过与 `vision_glance` 相同的多模态运行路径发送出去；它会创建一次真实 completion，并用于权威确认所选端点、Credential、模型、协议和上游账户确实能够处理图片。视觉模型检查卡会单独显示“已实测”“未测试”或“测试失败”Tag，避免把 `/models` 返回 HTTP 200 误认为图片调用成功。插件加载和普通 Settings 读取不会发送这两类请求。
-
-健康检查、连接测试以及插件/上游版本检查属于 Web Settings 管理能力，而不是模型工具，因此其 schema 永远不会占用 agent 请求上下文。
-
-## 产物与展示
-
-会生成产物的工具只能写入 `<workspace>/.dsh-vision-toolkit/artifacts`，写入形式为单个已验证文件或原子提交的运行目录。每个模型可见产物描述都包含路径、文件名、MIME 类型、种类、说明、来源工具、预览意图和字节数，因此 Headless agent 无需浏览器支持，也能在后续调用中复用该路径。提交 trace SVG 前，运行时会把它作为 XML 解析：允许标准声明与注释，但拒绝 doctype、格式错误或多根文档、非 SVG namespace，以及上游报告与实际路径数/字节数不一致的结果。
-
-存在 Web HTTP 宿主时，仅供展示的元数据会加入带签名的预览和下载能力 URL，而不改变规范工具结果。每次读取都会重新验证签名、managed 根目录围栏、路径组件、普通文件状态、大小、可用时的 device/inode 身份、扩展名和 MIME。SVG 响应使用禁止外部资源的 sandbox CSP，客户端通过 sandbox iframe 渲染。没有 HTTP 宿主时，同一张卡片保留 `openFile` 提供的“打开文件”能力，并显示产物描述，不会伪造无法访问的 URL。
-
-## 使用方式
-
-### 基础调用
-
-```text
-vision_glance images=["screenshot.png"] query="What error is shown?"
-vision_ground image="screenshot.png" target="the send button" preview=true
-vision_detect image="screenshot.png" category="buttons" preview=true
-vision_crop image="screenshot.png" region="1067,841,1108,881"
-vision_trace image="icon.png" color=true output="icon.svg"
-vision_pixel_diff original="reference.png" rebuilt="actual.png" runName="comparison"
-vision_long_screenshot_ocr image="page.png" mode="general" jobs=2
-vision_extract_foreground image="logo.png" mode="color"
-vision_dominant_colors image="screen.png" region="0,0,600,300" top=8
-vision_html_screenshot source="implementation.html" width=1200 height=720
-```
-
-常见工作流包括 `vision_ground` → `vision_crop` → `vision_glance`、`vision_ground` → `vision_crop` → `vision_trace`，以及参考图 → `vision_html_screenshot` → `vision_pixel_diff`。Grounding 和 detection 坐标始终使用原图像素（`x1/y1/x2/y2`）。
-
-### UI 还原示例
-
-已提交的 [UI 还原示例](examples/ui-restoration/README.md) 通过 `vision_html_screenshot` 渲染参考页面、故意不准确的初版实现和最终实现，再通过 `vision_pixel_diff` 比较两个候选结果：
-
-```sh
-npm run example:ui-restoration
-npm run example:ui-restoration:write
-```
-
-已提交证据记录初版差异为 `6.04%`，有 6 个非零最差区域；最终差异为 `0%`，没有非零最差区域。Check 模式会复现工具调用路径并验证已提交资源；write 模式会有意刷新证据。
-
-## 安全与执行模型
-
-- 输入相对会话工作区和配置的 `allowedDirs` 解析；realpath containment 阻止路径穿越和符号链接逃逸。
-- 每张图片都会在远程请求前由 Pillow 解码，并校验字节、像素、尺寸以及扩展名与内容是否一致。不支持或过大的图片会在上传前失败。
-- 输出使用真实 managed 目标目录中的随机 staging 文件或目录，拒绝符号链接，并只在格式与契约验证通过后提交。
-- 远程视觉提示词明确将图片中的文字和指令归类为不可信内容。原生工具描述与打包 skill 同样要求文本 agent 只把衍生描述、标签和 OCR 当作视觉证据，而不是可执行指令。
-- 所有上游进程都通过 `ctx.subprocess` 使用 argv 向量，继承调用方取消信号，共享一个完整操作硬截止时间，并随操作终止，不会继续在后台运行。插件释放会在注销对应工具前中止活动调用。
-- 一个活动会话只保留最近一次成功的 `vision_glance` 结果。只有图片内容、问题/OCR 模式、区域、端点、模型、语言和 Credential 都未改变时，紧接着的重复调用才会复用该结果；失败调用和其他会话绝不共享此条目。
-- 模型可见数据仅包含文本、数字、坐标、结构化 JSON 和文件描述。工具调用/结果可以从会话日志重建；浏览器预览只属于展示元数据。
-- 指标包含工具名、总耗时/上游耗时、有界图片数量/字节/像素、缓存命中、模型和错误类别；不包含 base64、鉴权头、密钥或无界上游输出。
-
-`vision_html_screenshot` 只接受已授权的本地 `.html` 或 `.htm` 文件，在固定适配器中禁用网络，并使用 `--headless=new`、`--use-mock-keychain`、`--incognito` 和系统临时目录内的唯一 `--user-data-dir` 启动 Chrome 系浏览器。每次调用后都会删除该 profile，因此无头渲染不会接触用户日常 Chrome Profile 或 macOS 登录钥匙串。
-
-## 故障排查
-
-| 症状 | 解决方法 |
+| 问题 | 处理方式 |
 |---|---|
-| `Model "..." does not support image input. (attachment-error)` | 图片走了 DSH 的模型原生附件通道，纯文本模型会在 Skill 或 Vision Toolkit 运行前拒绝该轮。启用图片输入变体时这很少发生：粘贴会自动把会话切换到 `<模型名> (Vision Toolkit)` 变体。若变体被关闭或自动切换被禁用，请使用 DSH Paste Input 的附件按钮、粘贴或拖放流程，让文件先复制到会话工作区并以路径形式进入消息，再调用 `/vision-tools`。安装或升级任一浏览器插件后，需要重启 Web Profile 并刷新页面。 |
-| Credential 显示缺失 | 在 Web 设置页的 **API 密钥** 中粘贴密钥，确认高级设置中的 **凭据名称** 与 `provider.credential` 一致，保存后重新运行健康检查。Headless 部署可以在 `$DSH_HOME/.credentials.yaml` 中预置同名引用。本地工具不需要它。 |
-| 运行时准备失败 | 查看 Settings 中的运行时错误，检查 Python 3.11+、软件包缓存/网络、磁盘权限和精确 external 固定版本。修正候选后再保存；当前 generation 不受影响。 |
-| 找不到 Chrome | 安装 Chrome、Chromium 或 Edge，或让其中一个可被运行环境发现。只有 `vision_html_screenshot` 不可用。 |
-| macOS 弹出钥匙串对话框 | 确认安装的是当前构建产物，且没有遗留的外部 `html_shot`/headless Chrome 进程。当前启动使用 mock keychain 和一次性 profile；取消对话框，不要重置登录钥匙串。 |
-| 输入或输出路径被拒绝 | 把文件移入会话工作区，或有意将真实目录加入 `allowedDirs`；移除会逃逸的符号链接。输出参数只接受文件名，不接受绝对路径或嵌套路径。 |
-| 视觉服务返回 401/403 | 替换 Credential 值，或选择正确的引用和端点。错误内容保持脱敏。 |
-| 视觉服务返回 429 | 等待提供方限流窗口结束后重试，或降低 `concurrency`。插件不会静默切换提供方。 |
-| 操作超时或被取消 | 在 1000-600000 毫秒范围内提高 `timeoutMs`、减少图片/分块工作量，或在取消后重新执行。子进程/请求会随操作停止。 |
-| Settings 保存冲突 | 重新加载分区以取得当前 revision，重新应用目标修改，再次保存。 |
-| Settings 只读 | 更换活动 Settings 提供方，或编辑其拥有的 Profile 配置；插件不能绕过提供方可写性。 |
-| 无法预览产物 | 使用“打开文件”或模型可见路径。只有 Web HTTP 路由已挂载时才存在预览/下载 URL。 |
+| 粘贴图片后仍提示模型不支持图片 | 重启 Web Profile 并刷新页面，确认当前模型已切换到带 `(Vision Toolkit)` 的变体；也可以把图片先放进会话工作区，再调用 `/vision-tools` |
+| 免费服务提示 429 | 按错误中的 `Retry-After` 等待后重试；如果需要稳定高额度，切换到自己的视觉端点 |
+| 图片过大或像素超限 | 先裁剪或缩放图片；错误会明确显示是字节还是像素限制 |
+| 自定义 Credential 缺失 | 在 **设置 → 视觉工具** 填写 API Key，并确认 Credential 名称与配置一致 |
+| 首次运行时准备失败 | 检查 Python 3.11+、网络或包缓存、磁盘权限，然后在 Settings 中重新测试 |
+| 找不到 Chrome | 安装 Chrome、Chromium 或 Edge；只有 HTML 截图不可用，其他工具不受影响 |
+| 产物无法预览 | 使用“打开文件”或结果中的工作区路径；预览 URL 只在 Web 路由可用时存在 |
 
-## 开发与验证
+## 项目状态与限制
+
+当前版本专注于截图理解、视觉定位、OCR、素材提取、UI 还原和像素级验证。它不是视频/音频/摄像头输入系统，也不会自动点击 GUI；交互式标注编辑、远程服务集群、模型投票和跨会话视觉缓存也不在当前范围内。
+
+## 开发与社区
 
 ```sh
 pnpm install --frozen-lockfile --trust-lockfile
 pnpm run verify:portable
 pnpm run build
 pnpm test
-pnpm run example:ui-restoration
-pnpm pack --dry-run
+TSX_TSCONFIG_PATH=tsconfig.json pnpm dlx tsx scripts/ui-restoration-example.ts --check
 ```
 
-`pnpm run verify:portable` 是不依赖外部开发包的可移植验证门禁：验证上游快照、package 元数据与 exports、已提交 JavaScript 语法、README 链接和图片、必需的开源门面文件、social preview 尺寸以及 dry-run tarball。完整 TypeScript 构建和测试会在这个独立 checkout 中直接使用 lockfile 锁定的 DSH `0.1.0-rc.6` registry 包；客户端构建还通过独立 compiler face 验证这些包的公开 exports，不使用内部路径 alias。PATH 中存在兼容的 `dsh` 与 `pnpm` 时会执行真实 Profile 验收，CI 会强制要求该路径，而不会静默跳过。
+- 贡献前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
+- Bug、功能建议和使用问题请提交到 [GitHub Issues](https://github.com/Anionex/dsh-vision-toolkit/issues)；渠道说明见 [SUPPORT.md](SUPPORT.md)。
+- 安全漏洞请按 [SECURITY.md](SECURITY.md) 私下报告。
+- 版本变化见 [CHANGELOG.md](CHANGELOG.md)，赞助说明见 [FUNDING.md](FUNDING.md)。
+- 通用视觉工具、跨 Agent 接入和视觉任务方法论请访问上游 [agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit)。
 
-`pnpm run build` 会先验证 vendored manifest，再生成 JavaScript、声明文件和 loader 兼容 Web 客户端。本包提交 `lib/`，因此从 checkout 安装时不要求消费方构建。无真实 Key 的真实 Profile 测试会安装到干净 `DSH_HOME`、启动 Headless、通过真实工具调用执行全部五个 P0 工具和具有代表性的 P1 本地/远程工具、验证禁用与重新启用行为，并卸载 Bundle。每项 P0/P1 需求对应的实现与验证位置见[需求追踪参考](docs/requirements-traceability/README.md)。
+<p align="center">
+  <img src="assets/community-group-qr.png" alt="agent-vision-toolkit 项目交流群二维码" width="240" />
+</p>
 
-更新上游快照时只能执行 `pnpm run upstream:sync -- <checkout>`，检查源码和许可证，重新生成 manifest，并在同一变更中更新适配器兼容性测试和已提交 `lib/`。运行时绝不拉取上游 `main`。
-
-## 项目状态与范围
-
-版本 `0.1.12` 是当前公开 npm 版本。产品重点是截图理解、视觉定位、OCR、素材提取、UI 还原和 DSH Web/Headless Profile 中的像素级验证。Web 上传、拖拽、摄像头/视频/音频/文档输入、交互式标注框编辑、GUI 自动点击、远程服务集群、模型路由、模型投票和跨会话视觉缓存不属于当前产品范围。
-
-<details>
-<summary><strong>维护者范围说明</strong></summary>
-
-稳定的 `ctx.visionToolkit` 服务和能力发现 API 会等到独立插件成为真实消费方后再发布。这样可以让公开集成面建立在已验证的使用场景上，而不是未经验证的生态契约上。
-
-</details>
-
-## 社区与关于
-
-- 提交代码、协议或上游快照变更前，请先阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
-- 可复现缺陷、范围明确的功能建议和使用问题请提交到 [GitHub Issues](https://github.com/Anionex/dsh-vision-toolkit/issues)；如何选择渠道见 [SUPPORT.md](SUPPORT.md)。
-- 安全漏洞必须按 [SECURITY.md](SECURITY.md) 私下报告，不要创建公开 Issue。
-- 版本与兼容性变化记录在 [CHANGELOG.md](CHANGELOG.md)。
-- 可选赞助方式与用途见 [FUNDING.md](FUNDING.md)；赞助不购买路线图优先级或私有支持。
-- 通用工具箱、跨 Harness 接入、视觉任务 playbook 和官方实跑案例请访问上游[项目网站](https://agent-vision.anionex.me)与[代码仓库](https://github.com/Anionex/agent-vision-toolkit)。
-- 如果 `agent-vision-toolkit` 的算法或方法节省了时间，欢迎为上游 star、分享、贡献或赞助；DSH 专属缺陷和集成需求请提交到本仓库。
-
-[`agent-vision-toolkit`](https://github.com/Anionex/agent-vision-toolkit) 由 [Anionex](https://anionex.me/) 创建。本仓库维护它面向 DeepSeek Harness 的原生集成：DSH 侧负责生命周期、安全、结构化 schema、Credentials、产物和 Web 展示；视觉算法与可复用 playbook 继续由上游项目维护。
-
-如果你想了解我后续的更多工作，欢迎在 [X](https://x.com/anion_ex) 或 [GitHub](https://github.com/Anionex) 关注我。
+[`agent-vision-toolkit`](https://github.com/Anionex/agent-vision-toolkit) 由 [Anionex](https://anionex.me/) 创建。本仓库维护它面向 DeepSeek Harness 的原生集成。
 
 ## 许可证
 
-插件采用 MIT 许可。打包的 `agent-vision-toolkit` 快照在 `vendor/agent-vision-toolkit/LICENSE` 保留上游 MIT 许可证，并继续作为视觉算法的唯一实现。
+插件采用 [MIT License](LICENSE)。打包的上游快照保留其原始 MIT 许可证，见 [`vendor/agent-vision-toolkit/LICENSE`](vendor/agent-vision-toolkit/LICENSE)。


### PR DESCRIPTION
## Summary

- rewrites the English and Chinese README around the problems users are trying to solve
- moves implementation detail behind progressive disclosure and shortens both documents from roughly 470 lines to about 310
- leads with keyless free Gemma 4 setup, task-focused vision, reusable outputs, and the UI restoration feedback loop
- adds a concise Recent updates section where every item states the user problem that was solved
- keeps installation, tool names, service limits, requirements, troubleshooting, and community links synchronized across both languages
- refreshes the bilingual pairing record

## Evidence

- facade audit: 95/100 before, 96/100 after; no failed checks or broken local targets
- the remaining quick-start warning is a scanner false negative: the audit recognizes the heading but does not classify `dsh plugin --profile web add ...` as a setup command
- UI restoration verifier reproduced 6.04% initial difference and 0% final difference at 1200 × 720

## Verification

- `CI=true pnpm run verify:portable`
- `pnpm run build`
- `pnpm test` — 246 passed, 1 skipped
- `TSX_TSCONFIG_PATH=tsconfig.json pnpm dlx tsx scripts/ui-restoration-example.ts --check`
- strict facade audit — 96/100, grade A, zero failed checks, zero broken local targets

## Browser / real-user verification

README-only change. Verify the GitHub-rendered English and Chinese READMEs: hero and badges render, language links switch correctly, proof images appear in matched pairs, collapsible sections open, and all local links resolve.