### PR TITLE
docs: note the Microsoft Store Python runtime fix in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable user-facing changes to DSH Vision Toolkit are documented in this file. The project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses semantic version tags.
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed managed runtime creation failing with exit status 101 when the Microsoft Store Python is used on Windows: the venv is now created with `--without-pip`, the staged `pyvenv.cfg` `home`/`executable` are rewritten to the app execution alias directory, and pip is bootstrapped explicitly.
+
 ## [0.1.12] - 2026-08-16
 
 ### Fixed


### PR DESCRIPTION
Adds an `[Unreleased]` entry for the merged `fix(runtime): support the Microsoft Store Python on Windows` (#39, commit `7285ccf`, with follow-up `0aa07d0`): venv creation now uses `--without-pip`, the staged `pyvenv.cfg` `home`/`executable` are rewritten to the app execution alias directory, and pip is bootstrapped explicitly so the venv launcher never has to `CreateProcess` the AppModel-restricted `python.exe`.

The v0.1.12 release was cut before this fix landed, so the next release would otherwise ship it without a changelog entry.