### PR TITLE
test: make source-map and paste-path assertions Windows-portable

### DIFF
--- a/tests/image-input-variants.spec.ts
+++ b/tests/image-input-variants.spec.ts
@@ -185,7 +185,7 @@ describe('convertImagesToEvidence', () => {
 
   it('keeps a native attachment in the session workspace and exposes its path beside the description', async () => {
     const glance = vi.fn(async (request: { images: string[] }) => {
-      expect(request.images[0]).toContain('/.dsh-vision-toolkit/tmp/pasted-images/')
+      expect(request.images[0]?.replaceAll('\\', '/')).toContain('/.dsh-vision-toolkit/tmp/pasted-images/')
       return glanceResult('path-aware description')
     })
     const attachments = { readImage: vi.fn(async () => ({ ref: attachment('native-a'), data: Uint8Array.of(7, 8, 9) })) }

--- a/tests/package-layout.spec.ts
+++ b/tests/package-layout.spec.ts
@@ -137,7 +137,7 @@ describe('package layout contract', () => {
         map: { sources: string[] }
       }>
     }
-    const outputLines = client.split('\n')
+    const outputLines = client.split(/\r?\n/u)
     expect(indexedMap.sections.length).toBeGreaterThan(1)
     for (const section of indexedMap.sections) {
       const source = section.map.sources[0]


### PR DESCRIPTION
Two `tests/` fixes so the suite is green on Windows checkouts (`core.autocrlf=true`); both already pass on Linux CI, which is why they went unnoticed.

1. `tests/package-layout.spec.ts`: the client source-map test did `client.split('\n')` and then an exact-match `indexOf` for the `__modules["./index.js"] = ...` wrapper line. On Windows the checked-out `lib/client.js` has CRLF endings, so every line carries a trailing `\r` and the exact match misses (`-1`). Splitting on `/\r?\n/` restores the match.

2. `tests/image-input-variants.spec.ts`: the evidence-conversion test asserted the pasted-image path contains the POSIX form `'/.dsh-vision-toolkit/tmp/pasted-images/'`. On Windows the absolute path uses `\` separators, so the glance mock's `expect` threw and the conversion produced no text block. Normalizing separators with `replaceAll('\\\\', '/')` keeps the Linux assertion and makes it pass on Windows.

Verified locally on Windows: both specs pass (61/61 tests).