### PR TITLE
docs: scope the upstream slogan to DSH

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write dsh-vision-toolkit/README.md
-README.md: dfdd97b87427ba03336b12abb7397f187287cff6
-README.zh.md: 90bce8c54d2ff09eedd578553631bc5cb168bf14
+README.md: 18dc1f444317ab1d272b222d3e7371cd23169967
+README.zh.md: c85d9e437996776236b08e9247ac639f60103236

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![MIT](https://img.shields.io/badge/license-MIT-0B7285?style=flat-square)](LICENSE)
 [![DSH](https://img.shields.io/badge/DSH-Web%20%2B%20Headless-5B4CF0?style=flat-square)](cordis.patch.yml)
 
-**Give any text-only coding agent eyes: image Q&A, long-screenshot OCR, UI restoration, and GUI visual tasks in one toolkit and Skill.**
+**Give text-only DeepSeek Harness agents eyes: image Q&A, long-screenshot OCR, UI restoration, and GUI visual tasks in one toolkit and Skill.**
 
 🎯 Visual capability does not have to live inside the model. It can live in the harness.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -12,7 +12,7 @@
 [![MIT](https://img.shields.io/badge/license-MIT-0B7285?style=flat-square)](LICENSE)
 [![DSH](https://img.shields.io/badge/DSH-Web%20%2B%20Headless-5B4CF0?style=flat-square)](cordis.patch.yml)
 
-**所想即所见——给任意纯文本 coding agent 装上眼睛：图片问答、长图 OCR、前端 UI 还原、GUI 视觉任务，一套视觉工具箱和一个 Skill。**
+**所想即所见——给 DeepSeek Harness 里的纯文本 Agent 装上眼睛：图片问答、长图 OCR、前端 UI 还原、GUI 视觉任务，一套视觉工具箱和一个 Skill。**
 
 🎯 视觉能力不一定长在模型上，也可以长在 harness 上。
 


### PR DESCRIPTION
## Summary

- scopes the inherited slogan to text-only agents inside DeepSeek Harness
- keeps the upstream product language while avoiding the incorrect “any coding agent” promise for this DSH plugin
- updates English and Chinese README pairing hashes

## Verification

- strict facade audit: 100/100, grade A, zero failed checks, zero broken local targets
- `git diff --check`

Documentation-only change; the dshfind 94-point badge and all DSH-specific positioning remain unchanged.