### PR TITLE
release: v0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 ## [Unreleased]
 
+## [0.1.15] - 2026-08-16
+
+### Fixed
+
+- Fixed the Settings runtime health check reporting a false artifact-directory failure when DSH Desktop starts from a read-only installation directory. The check now uses the prepared runtime home and validates output readiness independently from session-relative input directories.
+
 ## [0.1.14] - 2026-08-16
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anionex/dsh-vision-toolkit",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "DeepSeek Harness-native integration for agent-vision-toolkit: image Q&A, OCR, grounding, UI restoration, pixel diff, Artifacts, and Web UI.",
   "keywords": [
     "deepseek",


### PR DESCRIPTION
## Summary

Release `@anionex/dsh-vision-toolkit` v0.1.15.

This patch release ships the fix from #63 for Settings runtime health checks on DSH Desktop installations whose current working directory is read-only, including the follow-up protection against session-relative `allowedDirs` causing another false artifact-directory failure.

## Release changes

- Bump package version from `0.1.14` to `0.1.15`.
- Add the v0.1.15 changelog entry.

## Verification

- `node_modules/.bin/vitest run tests/package-layout.spec.ts tests/web.spec.ts tests/runtime.spec.ts` — 76 passed.
- `node_modules/.bin/vitest run tests` — 271 passed, 1 skipped across 21 files.
- Package build — passed.
- `node scripts/verify-portable.mjs` — passed.
- `npm pack --dry-run` — verified `@anionex/dsh-vision-toolkit@0.1.15`, 171 package entries.

This is a non-UI patch release; browser E2E is not applicable.
