### PR TITLE
docs: clarify original vision toolkit design

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write dsh-vision-toolkit/README.md
-README.md: 7beef0b9563811b385f5e49bc75ecaa8a21bc30f
-README.zh.md: 93af175e51981174987f63c7c2e1f037f133293c
+README.md: 5e74d8481ca52466a0d33fe1d1101bbe6e39461b
+README.zh.md: 68330dcafe232dd929e4d2a7e0ef260b0768ee05

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you use DeepSeek or another text-only model in DeepSeek Harness (DSH), you ma
 
 🏆 This project is the first comprehensive vision-tool plugin in the DeepSeek Harness ecosystem: it was initiated before internal beta and built during the beta with reference to [`agent-vision-toolkit`](https://github.com/Anionex/agent-vision-toolkit).
 
-> **Original work:** This vision toolkit and the `vision-tools` Skill were personally created and continuously refined by the author through long-term real-world use and repeated iteration.
+> **Original work:** The system and division of responsibilities behind these visual tools, together with the `vision-tools` Skill, were personally created and continuously refined by the author through long-term real-world use and repeated iteration.
 
 ## Highlights
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -28,7 +28,7 @@
 
 🏆 本项目为deepseek harness生态首个综合性视觉工具插件：内测前已立项，并在内测期间参考本人的[`agent-vision-toolkit`](https://github.com/Anionex/agent-vision-toolkit)做出
 
-> **原创声明：** 这套视觉工具和 `vision-tools` Skill 由作者个人原创并持续打磨，相关工具、方法和工作流来自长期的真实使用与反复迭代。
+> **原创声明：** 这套视觉工具的体系和划分方式，以及 `vision-tools` Skill，均由作者个人原创并持续打磨，相关工具、方法和工作流来自长期的真实使用与反复迭代。
 
 ## 亮点
 


### PR DESCRIPTION
## Summary
- clarify that the visual-tool system, its division of responsibilities, and the `vision-tools` Skill are original work
- update the English and Chinese README together
- refresh the bilingual pairing hashes

## Verification
- README bilingual pairing hashes verified with `git hash-object`
- `git diff --check`
