### PR TITLE
release: publish v0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 ## [Unreleased]
 
+## [0.1.17] - 2026-08-16
+
+### Changed
+
+- Clarified in both READMEs that the visual-tool system, its division of responsibilities, and the `vision-tools` Skill are original work, and refreshed the bilingual pairing record.
+
 ## [0.1.16] - 2026-08-16
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anionex/dsh-vision-toolkit",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "DeepSeek Harness-native integration for agent-vision-toolkit: image Q&A, OCR, grounding, UI restoration, pixel diff, Artifacts, and Web UI.",
   "keywords": [
     "deepseek",


### PR DESCRIPTION
## Summary
- publish `@anionex/dsh-vision-toolkit@0.1.17`
- include the bilingual README originality clarification in the npm package metadata and release history

## Verification
- `pnpm test` — 273 passed, 1 skipped
- `pnpm build`
- `pnpm verify:portable`
- `npm pack --dry-run --json` — package `0.1.17`, 171 files
- `git diff --check`
