### PR TITLE
release: publish v0.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 ## [Unreleased]
 
+## [0.1.18] - 2026-08-16
+
 ### Changed
 
 - Rebased the model-facing `vision-tools` Skill on the upstream `SKILL.md` and
@@ -12,10 +14,17 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 - Added an exact upstream Skill commit/hash manifest, a reviewable adapter
   patch, and repeatable sync/verification commands so future upstream updates
   fail closed when the adaptation no longer applies cleanly.
+- Expanded the built-in free vision service capacity and provider pool to
+  reduce peak-time exhaustion without changing the existing client safeguard.
+- Replaced the built-in public compatibility key with the project URL while
+  continuing to accept the legacy `api_key="free"` value for existing installs.
+- Reduced the default vision operation timeout from 60 seconds to 15 seconds.
 
 ### Fixed
 
 - Removed the stale single-image restriction from the public Groq vision proxy; one request can now forward up to five images in their original order.
+- Returned sanitized Groq validation details and descriptive request-size errors instead of retrying non-retryable failures across every provider account.
+- Returned explicit quota `429` responses immediately, including retry guidance, instead of retrying them until the client reported a timeout.
 
 ## [0.1.17] - 2026-08-16
 
@@ -210,7 +219,11 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 - Runtime teardown cancels in-flight operations before removing Agent-scoped tools, the activation bootstrap, and the Skill.
 - The Web client is published through the current nested `dsh.client` manifest and loader-compatible built artifact required by DSH snapshot0810.
 
-[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.14...HEAD
+[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.18...HEAD
+[0.1.18]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.17...v0.1.18
+[0.1.17]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.16...v0.1.17
+[0.1.16]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.15...v0.1.16
+[0.1.15]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.12...v0.1.13
 [0.1.12]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.11...v0.1.12

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anionex/dsh-vision-toolkit",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "DeepSeek Harness-native integration for agent-vision-toolkit: image Q&A, OCR, grounding, UI restoration, pixel diff, Artifacts, and Web UI.",
   "keywords": [
     "deepseek",


### PR DESCRIPTION
## Summary
- bump `@anionex/dsh-vision-toolkit` to `0.1.18`
- move the current Unreleased entries into the `0.1.18` release notes
- document the updated Skill, multi-image support, clearer Groq errors, expanded shared capacity, branded public key compatibility, immediate quota errors, and 15-second default timeout
- repair the missing changelog comparison links for releases `0.1.15` through `0.1.18`

## Verification
- `pnpm run build`
- `pnpm test` (276 passed, 1 skipped)
- `pnpm run verify:portable`
- `PYTHONDONTWRITEBYTECODE=1 python3 vendor/agent-vision-toolkit/tests/test_vision_client.py`
- Worker `pnpm run check` (42 passed)
- Worker `pnpm run deploy:check`
- `npm pack --dry-run --json`
- authenticated npm publishing identity verified as `anionex` against the official registry