### PR TITLE
feat(worker): add another vision upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 ## [Unreleased]
 
+### Changed
+
+- Added another OpenAI-compatible vision endpoint to the persistent least-active upstream pool, so it can carry requests when the primary accounts are cooling down or rejected.
+
+### Fixed
+
+- Return the standard non-retryable `rate_limit_exceeded` code when every upstream is cooling down, preventing the 15-second client deadline from hiding an immediate provider-capacity response as a timeout.
+
 ## [0.1.20] - 2026-08-17
 
 ### Changed

--- a/workers/moondream-openai-proxy/migrations/0003_add_fallback_upstream.sql
+++ b/workers/moondream-openai-proxy/migrations/0003_add_fallback_upstream.sql
@@ -1,0 +1,1 @@
+INSERT OR IGNORE INTO groq_key_state (key_slot) VALUES (5);

--- a/workers/moondream-openai-proxy/scripts/deploy.mjs
+++ b/workers/moondream-openai-proxy/scripts/deploy.mjs
@@ -34,6 +34,9 @@ try {
     'GROQ_API_KEY_3',
     'GROQ_API_KEY_4',
     'GROQ_API_KEY_5',
+    'FALLBACK_VISION_API_KEY',
+    'FALLBACK_VISION_MODEL',
+    'FALLBACK_VISION_URL',
   ]
   const missingSecrets = requiredSecrets.filter(name => !new RegExp(`"name"\\s*:\\s*"${name}"`).test(secrets))
   if (missingSecrets.length > 0) {

--- a/workers/moondream-openai-proxy/src/groq.ts
+++ b/workers/moondream-openai-proxy/src/groq.ts
@@ -7,17 +7,20 @@ const AUTH_COOLDOWN_MS = 15 * 60 * 1000
 const RATE_LIMIT_COOLDOWN_MS = 60_000
 const TRANSIENT_COOLDOWN_MS = 5_000
 
-interface GroqSecrets {
+interface ProviderSecrets {
   GROQ_API_KEY_1?: string
   GROQ_API_KEY_2?: string
   GROQ_API_KEY_3?: string
   GROQ_API_KEY_4?: string
   GROQ_API_KEY_5?: string
+  FALLBACK_VISION_API_KEY?: string
+  FALLBACK_VISION_MODEL?: string
+  FALLBACK_VISION_URL?: string
 }
 
-type GroqEnv = Env & GroqSecrets
+type ProviderEnv = Env & ProviderSecrets
 
-export class GroqProviderError extends Error {
+export class VisionProviderError extends Error {
   constructor(
     message: string,
     readonly status: number,
@@ -25,20 +28,42 @@ export class GroqProviderError extends Error {
     readonly retryAfter?: string,
   ) {
     super(message)
-    this.name = 'GroqProviderError'
+    this.name = 'VisionProviderError'
   }
 }
 
-function configuredKeys(env: GroqEnv): string[] {
-  return [
-    env.GROQ_API_KEY_1,
-    env.GROQ_API_KEY_2,
-    env.GROQ_API_KEY_3,
-    env.GROQ_API_KEY_4,
-    env.GROQ_API_KEY_5,
+interface VisionUpstream {
+  endpoint: string
+  key: string
+  model: string
+  name: 'groq' | 'fallback'
+  slot: number
+}
+
+function configuredUpstreams(env: ProviderEnv): VisionUpstream[] {
+  const candidates: Array<Omit<VisionUpstream, 'key'> & { key?: string }> = [
+    { endpoint: GROQ_CHAT_COMPLETIONS_URL, key: env.GROQ_API_KEY_1, model: CANONICAL_MODEL, name: 'groq', slot: 0 },
+    { endpoint: GROQ_CHAT_COMPLETIONS_URL, key: env.GROQ_API_KEY_2, model: CANONICAL_MODEL, name: 'groq', slot: 1 },
+    { endpoint: GROQ_CHAT_COMPLETIONS_URL, key: env.GROQ_API_KEY_3, model: CANONICAL_MODEL, name: 'groq', slot: 2 },
+    { endpoint: GROQ_CHAT_COMPLETIONS_URL, key: env.GROQ_API_KEY_4, model: CANONICAL_MODEL, name: 'groq', slot: 3 },
+    { endpoint: GROQ_CHAT_COMPLETIONS_URL, key: env.GROQ_API_KEY_5, model: CANONICAL_MODEL, name: 'groq', slot: 4 },
   ]
-    .map(value => value?.trim())
-    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+  const fallbackKey = env.FALLBACK_VISION_API_KEY?.trim()
+  const fallbackEndpoint = env.FALLBACK_VISION_URL?.trim()
+  const fallbackModel = env.FALLBACK_VISION_MODEL?.trim()
+  if (fallbackKey && fallbackEndpoint && fallbackModel) {
+    candidates.push({
+      endpoint: fallbackEndpoint,
+      key: fallbackKey,
+      model: fallbackModel,
+      name: 'fallback',
+      slot: 5,
+    })
+  }
+  return candidates.flatMap((candidate) => {
+    const key = candidate.key?.trim()
+    return key ? [{ ...candidate, key }] : []
+  })
 }
 
 interface KeyLease {
@@ -46,16 +71,18 @@ interface KeyLease {
 }
 
 /** Cross-isolate key allocator backed by the Worker's existing D1 database. */
-export class GroqKeyScheduler {
+export class VisionUpstreamScheduler {
   constructor(private readonly database: D1Database) {}
 
-  async acquire(keyCount: number): Promise<KeyLease | undefined> {
+  async acquire(slots: number[]): Promise<KeyLease | undefined> {
+    if (slots.length === 0) return undefined
     const now = Date.now()
     await this.database.prepare(`
       UPDATE groq_key_state
       SET active_requests = 0, lease_expires_at = 0, updated_at = ?1
       WHERE active_requests > 0 AND lease_expires_at <= ?1
     `).bind(now).run()
+    const slotParameters = slots.map((_, index) => `?${index + 3}`).join(', ')
     const lease = await this.database.prepare(`
       UPDATE groq_key_state
       SET
@@ -66,12 +93,12 @@ export class GroqKeyScheduler {
       WHERE key_slot = (
         SELECT key_slot
         FROM groq_key_state
-        WHERE key_slot < ?3 AND cooldown_until <= ?1
+        WHERE key_slot IN (${slotParameters}) AND cooldown_until <= ?1
         ORDER BY active_requests ASC, last_selected_at ASC, key_slot ASC
         LIMIT 1
       )
       RETURNING key_slot
-    `).bind(now, now + KEY_LEASE_MS, keyCount).first<{ key_slot: number }>()
+    `).bind(now, now + KEY_LEASE_MS, ...slots).first<{ key_slot: number }>()
     return lease === null ? undefined : { slot: lease.key_slot }
   }
 
@@ -88,13 +115,15 @@ export class GroqKeyScheduler {
     `).bind(now, now + cooldownMs, slot).run()
   }
 
-  async retryAfterSeconds(keyCount: number): Promise<string | undefined> {
+  async retryAfterSeconds(slots: number[]): Promise<string | undefined> {
+    if (slots.length === 0) return undefined
     const now = Date.now()
+    const slotParameters = slots.map((_, index) => `?${index + 1}`).join(', ')
     const next = await this.database.prepare(`
       SELECT MIN(cooldown_until) AS cooldown_until
       FROM groq_key_state
-      WHERE key_slot < ?1 AND cooldown_until > ?2
-    `).bind(keyCount, now).first<{ cooldown_until: number | null }>()
+      WHERE key_slot IN (${slotParameters}) AND cooldown_until > ?${slots.length + 1}
+    `).bind(...slots, now).first<{ cooldown_until: number | null }>()
     if (typeof next?.cooldown_until !== 'number') return undefined
     return String(Math.max(1, Math.ceil((next.cooldown_until - now) / 1000)))
   }
@@ -124,7 +153,7 @@ function cooldownForStatus(status: number, retryAfter: string | null): number {
 }
 
 async function releaseLease(
-  scheduler: GroqKeyScheduler,
+  scheduler: VisionUpstreamScheduler,
   slot: number,
   requestId: string,
   cooldownMs = 0,
@@ -134,8 +163,8 @@ async function releaseLease(
   } catch (error) {
     console.error(JSON.stringify({
       error: error instanceof Error ? error.message : String(error),
-      event: 'groq_lease_release_failed',
-      keySlot: slot + 1,
+      event: 'vision_upstream_lease_release_failed',
+      upstreamSlot: slot + 1,
       requestId,
     }))
   }
@@ -172,69 +201,76 @@ async function readUpstreamErrorMessage(response: Response, keys: string[]): Pro
   }
 }
 
-function invalidRequestError(status: number, message?: string): GroqProviderError {
+function invalidRequestError(status: number, message?: string): VisionProviderError {
   const detail = message ? `: ${message}` : ''
   if (status === 413) {
-    return new GroqProviderError(
+    return new VisionProviderError(
       `Vision provider rejected the request because it is too large${detail}`,
       413,
       'upstream_request_too_large',
     )
   }
   if (status === 404) {
-    return new GroqProviderError('Vision model is temporarily unavailable', 502, 'upstream_model_unavailable')
+    return new VisionProviderError('Vision model is temporarily unavailable', 502, 'upstream_model_unavailable')
   }
-  return new GroqProviderError(
+  return new VisionProviderError(
     `Vision provider rejected the request${detail}`,
     status === 422 ? 422 : 400,
     'upstream_invalid_request',
   )
 }
 
-export async function runGroqCompletion(
+export async function runVisionCompletion(
   input: VisionInput,
-  env: GroqEnv,
+  env: ProviderEnv,
   requestId: string,
 ): Promise<VisionOutput> {
-  const keys = configuredKeys(env)
-  if (keys.length === 0) {
-    throw new ProtocolError('Groq vision provider is not configured', {
+  const upstreams = configuredUpstreams(env)
+  if (upstreams.length === 0) {
+    throw new ProtocolError('Vision providers are not configured', {
       code: 'service_configuration_error',
       status: 503,
     })
   }
 
-  const scheduler = new GroqKeyScheduler(env.USAGE_DB)
+  const scheduler = new VisionUpstreamScheduler(env.USAGE_DB)
+  const upstreamBySlot = new Map(upstreams.map(upstream => [upstream.slot, upstream]))
+  const slots = upstreams.map(upstream => upstream.slot)
+  const secrets = upstreams.map(upstream => upstream.key)
   const statuses: number[] = []
   let lastRetryAfter: string | undefined
   let poolUnavailable = false
 
-  for (let attempt = 0; attempt < keys.length; attempt += 1) {
-    const lease = await scheduler.acquire(keys.length)
+  for (let attempt = 0; attempt < upstreams.length; attempt += 1) {
+    const lease = await scheduler.acquire(slots)
     if (lease === undefined) {
       poolUnavailable = true
-      lastRetryAfter = await scheduler.retryAfterSeconds(keys.length) ?? lastRetryAfter
+      lastRetryAfter = await scheduler.retryAfterSeconds(slots) ?? lastRetryAfter
       break
     }
-    const key = keys[lease.slot]!
+    const upstream = upstreamBySlot.get(lease.slot)
+    if (upstream === undefined) {
+      await releaseLease(scheduler, lease.slot, requestId, TRANSIENT_COOLDOWN_MS)
+      continue
+    }
     let response: Response
     try {
-      response = await fetch(GROQ_CHAT_COMPLETIONS_URL, {
+      response = await fetch(upstream.endpoint, {
         body: JSON.stringify({
-          model: CANONICAL_MODEL,
+          model: upstream.model,
           reasoning_effort: 'none',
           ...input,
         }),
         headers: {
-          authorization: `Bearer ${key}`,
+          authorization: `Bearer ${upstream.key}`,
           'content-type': 'application/json',
         },
         method: 'POST',
       })
     } catch {
       await releaseLease(scheduler, lease.slot, requestId, TRANSIENT_COOLDOWN_MS)
-      if (attempt + 1 < keys.length) continue
-      throw new GroqProviderError('Vision provider is temporarily unavailable', 502, 'upstream_error')
+      if (attempt + 1 < upstreams.length) continue
+      throw new VisionProviderError('Vision provider is temporarily unavailable', 502, 'upstream_error')
     }
 
     if (response.ok) {
@@ -243,15 +279,15 @@ export async function runGroqCompletion(
       try {
         payload = await response.json()
       } catch {
-        throw new GroqProviderError('Vision provider returned invalid JSON', 502, 'upstream_invalid_response')
+        throw new VisionProviderError('Vision provider returned invalid JSON', 502, 'upstream_invalid_response')
       }
       if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
-        throw new GroqProviderError('Vision provider returned an invalid response', 502, 'upstream_invalid_response')
+        throw new VisionProviderError('Vision provider returned an invalid response', 502, 'upstream_invalid_response')
       }
       return normalizeVisionOutput(payload as Record<string, unknown>)
     }
 
-    const upstreamMessage = await readUpstreamErrorMessage(response, keys)
+    const upstreamMessage = await readUpstreamErrorMessage(response, secrets)
     statuses.push(response.status)
     const retryAfter = response.headers.get('retry-after')
     const cooldownMs = cooldownForStatus(response.status, retryAfter)
@@ -261,28 +297,29 @@ export async function runGroqCompletion(
     console.warn(JSON.stringify({
       attempt: attempt + 1,
       cooldownMs,
-      event: 'groq_attempt_failed',
-      keySlot: lease.slot + 1,
+      event: 'vision_upstream_attempt_failed',
+      provider: upstream.name,
       requestId,
       status: response.status,
+      upstreamSlot: lease.slot + 1,
       ...(upstreamMessage === undefined ? {} : { upstreamMessage }),
     }))
     if (!isRetryableStatus(response.status)) throw invalidRequestError(response.status, upstreamMessage)
-    if (attempt + 1 >= keys.length) break
+    if (attempt + 1 >= upstreams.length) break
   }
 
   if (allRequestsWereRateLimited(statuses) || poolUnavailable) {
-    throw new GroqProviderError(
+    throw new VisionProviderError(
       'Vision provider rate limit reached; retry later',
       429,
-      'upstream_rate_limit_exceeded',
+      'rate_limit_exceeded',
       lastRetryAfter,
     )
   }
   if (statuses.length > 0 && statuses.every(status => status === 401 || status === 403)) {
-    throw new GroqProviderError('Vision provider credentials are unavailable', 502, 'upstream_authentication_error')
+    throw new VisionProviderError('Vision provider credentials are unavailable', 502, 'upstream_authentication_error')
   }
-  throw new GroqProviderError('Vision provider is temporarily unavailable', 502, 'upstream_error')
+  throw new VisionProviderError('Vision provider is temporarily unavailable', 502, 'upstream_error')
 }
 
-export const __test__ = { configuredKeys, cooldownForStatus, retryAfterMilliseconds, sanitizeUpstreamMessage }
+export const __test__ = { configuredUpstreams, cooldownForStatus, retryAfterMilliseconds, sanitizeUpstreamMessage }

--- a/workers/moondream-openai-proxy/src/index.ts
+++ b/workers/moondream-openai-proxy/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from './protocol'
 import { materializeImage } from './image'
 import { normalizeClientAddress } from './identity'
-import { GroqProviderError, runGroqCompletion } from './groq'
+import { VisionProviderError, runVisionCompletion } from './groq'
 
 const CORS_HEADERS = {
   'access-control-allow-headers': 'authorization, content-type, openai-organization, openai-project, x-stainless-arch, x-stainless-async, x-stainless-helper-method, x-stainless-lang, x-stainless-os, x-stainless-package-version, x-stainless-read-timeout, x-stainless-retry-count, x-stainless-runtime, x-stainless-runtime-version, x-stainless-timeout',
@@ -263,7 +263,7 @@ async function chatCompletion(request: Request, env: Env): Promise<Response> {
     const modelInput = buildVisionInput(completion, images, maxTokens)
 
     inferenceStarted = true
-    const output: VisionOutput = await runGroqCompletion(modelInput, env, requestId)
+    const output: VisionOutput = await runVisionCompletion(modelInput, env, requestId)
     const content = completionContent(output, completion.task)
     const usage = tokenUsage(output)
     const headers = new Headers({
@@ -310,7 +310,7 @@ async function chatCompletion(request: Request, env: Env): Promise<Response> {
         }))
       }
     }
-    if (error instanceof GroqProviderError) {
+    if (error instanceof VisionProviderError) {
       const headers = new Headers({ 'x-request-id': requestId })
       if (error.retryAfter) headers.set('retry-after', error.retryAfter)
       return openAiError(error.message, {

--- a/workers/moondream-openai-proxy/tests/worker.spec.ts
+++ b/workers/moondream-openai-proxy/tests/worker.spec.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import worker from '../src/index'
-import { __test__ as groqTest } from '../src/groq'
+import {
+  GROQ_CHAT_COMPLETIONS_URL,
+  __test__ as providerTest,
+} from '../src/groq'
 import { CANONICAL_MODEL } from '../src/protocol'
 
 const tinyPng = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
 const publicApiKey = 'https://agent-vision.anionex.me'
+const fallbackEndpoint = 'https://fallback.example/v1/chat/completions'
+const fallbackModel = 'fallback-vision-model'
 
 interface FakeKeyState {
   activeRequests: number
@@ -29,9 +34,9 @@ class FakeStatement {
     if (this.sql.includes('RETURNING key_slot')) {
       const now = Number(this.values[0])
       const leaseExpiresAt = Number(this.values[1])
-      const keyCount = Number(this.values[2])
+      const slots = new Set(this.values.slice(2).map(Number))
       const selected = [...this.database.keyStates.values()]
-        .filter(state => state.keySlot < keyCount && state.cooldownUntil <= now)
+        .filter(state => slots.has(state.keySlot) && state.cooldownUntil <= now)
         .sort((left, right) => left.activeRequests - right.activeRequests
           || left.lastSelectedAt - right.lastSelectedAt
           || left.keySlot - right.keySlot)[0]
@@ -42,10 +47,10 @@ class FakeStatement {
       return { key_slot: selected.keySlot } as T
     }
     if (this.sql.includes('MIN(cooldown_until)')) {
-      const keyCount = Number(this.values[0])
-      const now = Number(this.values[1])
+      const now = Number(this.values.at(-1))
+      const slots = new Set(this.values.slice(0, -1).map(Number))
       const next = [...this.database.keyStates.values()]
-        .filter(state => state.keySlot < keyCount && state.cooldownUntil > now)
+        .filter(state => slots.has(state.keySlot) && state.cooldownUntil > now)
         .reduce<number | null>((minimum, state) => minimum === null
           ? state.cooldownUntil
           : Math.min(minimum, state.cooldownUntil), null)
@@ -92,7 +97,7 @@ class FakeStatement {
 class FakeD1 {
   readonly counts = new Map<string, number>()
   failSchedulerRelease = false
-  readonly keyStates = new Map<number, FakeKeyState>(Array.from({ length: 5 }, (_, keySlot) => [
+  readonly keyStates = new Map<number, FakeKeyState>(Array.from({ length: 6 }, (_, keySlot) => [
     keySlot,
     { activeRequests: 0, cooldownUntil: 0, keySlot, lastSelectedAt: 0, leaseExpiresAt: 0 },
   ]))
@@ -146,6 +151,9 @@ function environment(database: FakeD1, burstSuccess = true): Env {
     GROQ_API_KEY_3: 'test-groq-key-3',
     GROQ_API_KEY_4: 'test-groq-key-4',
     GROQ_API_KEY_5: 'test-groq-key-5',
+    FALLBACK_VISION_API_KEY: 'test-fallback-key',
+    FALLBACK_VISION_MODEL: fallbackModel,
+    FALLBACK_VISION_URL: fallbackEndpoint,
     USAGE_DB: database,
   } as Env
 }
@@ -153,10 +161,59 @@ function environment(database: FakeD1, burstSuccess = true): Env {
 afterEach(() => vi.unstubAllGlobals())
 
 describe('Worker request accounting', () => {
-  it('trims configured Groq secrets before using them as bearer tokens', () => {
+  it('trims configured provider secrets before using them as bearer tokens', () => {
     const env = environment(new FakeD1()) as Env & Record<string, string>
     env.GROQ_API_KEY_1 = '  test-groq-key-1\n'
-    expect(groqTest.configuredKeys(env)).toContain('test-groq-key-1')
+    expect(providerTest.configuredUpstreams(env)).toContainEqual(expect.objectContaining({
+      key: 'test-groq-key-1',
+      slot: 0,
+    }))
+  })
+
+  it('keeps the additional endpoint on a stable scheduler slot', () => {
+    const upstream = providerTest.configuredUpstreams(environment(new FakeD1()))
+      .find(candidate => candidate.name === 'fallback')
+    expect(upstream).toMatchObject({
+      endpoint: fallbackEndpoint,
+      key: 'test-fallback-key',
+      model: fallbackModel,
+      slot: 5,
+    })
+  })
+
+  it('selects the stable additional slot when primary secrets are absent', async () => {
+    const database = new FakeD1()
+    const env = environment(database) as Env & Record<string, string | undefined>
+    for (let index = 1; index <= 5; index += 1) delete env[`GROQ_API_KEY_${index}`]
+    const providerFetch = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(fallbackEndpoint)
+      return Response.json({
+        choices: [{ finish_reason: 'stop', message: { content: 'Additional endpoint.', role: 'assistant' } }],
+      })
+    })
+    vi.stubGlobal('fetch', providerFetch)
+
+    const response = await worker.fetch(request(), env as Env)
+
+    expect(response.status).toBe(200)
+    expect(providerFetch).toHaveBeenCalledTimes(1)
+    expect(database.keyStates.get(5)).toMatchObject({ activeRequests: 0 })
+  })
+
+  it('returns the sparse additional slot cooldown without contacting an upstream', async () => {
+    const database = new FakeD1()
+    database.keyStates.get(5)!.cooldownUntil = Date.now() + 5_000
+    const env = environment(database) as Env & Record<string, string | undefined>
+    for (let index = 1; index <= 5; index += 1) delete env[`GROQ_API_KEY_${index}`]
+    const providerFetch = vi.fn()
+    vi.stubGlobal('fetch', providerFetch)
+
+    const response = await worker.fetch(request(), env as Env)
+
+    expect(response.status).toBe(429)
+    expect(response.headers.get('retry-after')).toMatch(/^[1-5]$/)
+    expect(await response.json()).toMatchObject({ error: { code: 'rate_limit_exceeded' } })
+    expect(providerFetch).not.toHaveBeenCalled()
   })
 
   it('advertises the branded public key on the discovery route', async () => {
@@ -319,11 +376,36 @@ describe('Worker request accounting', () => {
 
     const authorizations = groqFetch.mock.calls.map(call => new Headers(call[1]?.headers).get('authorization'))
     expect(new Set(authorizations).size).toBe(2)
-    expect([...database.keyStates.values()].map(state => state.activeRequests)).toEqual([1, 1, 0, 0, 0])
+    expect([...database.keyStates.values()].map(state => state.activeRequests)).toEqual([1, 1, 0, 0, 0, 0])
 
     releaseFetches?.()
     await expect(Promise.all([first, second])).resolves.toHaveLength(2)
-    expect([...database.keyStates.values()].map(state => state.activeRequests)).toEqual([0, 0, 0, 0, 0])
+    expect([...database.keyStates.values()].map(state => state.activeRequests)).toEqual([0, 0, 0, 0, 0, 0])
+  })
+
+  it('falls back to the additional endpoint when every primary account is rejected', async () => {
+    const database = new FakeD1()
+    const providerFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === GROQ_CHAT_COMPLETIONS_URL) return new Response('Forbidden', { status: 403 })
+      expect(String(input)).toBe(fallbackEndpoint)
+      expect(new Headers(init?.headers).get('authorization')).toBe('Bearer test-fallback-key')
+      expect(JSON.parse(String(init?.body))).toMatchObject({ model: fallbackModel, reasoning_effort: 'none' })
+      return Response.json({
+        choices: [{ finish_reason: 'stop', message: { content: 'Fallback recovered.', role: 'assistant' } }],
+      })
+    })
+    vi.stubGlobal('fetch', providerFetch)
+
+    const response = await worker.fetch(request(), environment(database))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      choices: [{ message: { content: 'Fallback recovered.' } }],
+    })
+    expect(providerFetch).toHaveBeenCalledTimes(6)
+    expect(providerFetch.mock.calls.slice(0, 5).every(call => String(call[0]) === GROQ_CHAT_COMPLETIONS_URL)).toBe(true)
+    expect(String(providerFetch.mock.calls[5]?.[0])).toBe(fallbackEndpoint)
+    expect([...database.keyStates.values()].map(state => state.activeRequests)).toEqual([0, 0, 0, 0, 0, 0])
   })
 
   it('keeps a successful inference response when lease cleanup fails', async () => {
@@ -339,7 +421,7 @@ describe('Worker request accounting', () => {
     expect(await response.json()).toMatchObject({
       choices: [{ message: { content: 'Still returned.' } }],
     })
-    expect(error).toHaveBeenCalledWith(expect.stringContaining('groq_lease_release_failed'))
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('vision_upstream_lease_release_failed'))
   })
 
   it('keeps the legacy free API key working during the public key migration', async () => {
@@ -364,7 +446,7 @@ describe('Worker request accounting', () => {
     })
   })
 
-  it('returns a sanitized upstream error when all Groq accounts are rate limited', async () => {
+  it('returns a non-retryable rate-limit code when every upstream is cooling down', async () => {
     const database = new FakeD1()
     const groqFetch = vi.fn(async () => new Response('rate limited', { status: 429 }))
     vi.stubGlobal('fetch', groqFetch)
@@ -372,9 +454,9 @@ describe('Worker request accounting', () => {
     expect(response.status).toBe(429)
     const payload = await response.json()
     expect(payload).toMatchObject({
-      error: { code: 'upstream_rate_limit_exceeded' },
+      error: { code: 'rate_limit_exceeded' },
     })
-    expect(groqFetch).toHaveBeenCalledTimes(5)
+    expect(groqFetch).toHaveBeenCalledTimes(6)
     expect(JSON.stringify(payload)).not.toContain('test-groq-key')
   })
 


### PR DESCRIPTION
## Summary
- add another OpenAI-compatible vision endpoint as slot 6 in the persistent least-active upstream pool
- keep scheduler slots stable even when one or more primary secrets are absent
- return the standard non-retryable `rate_limit_exceeded` code when every upstream is cooling down
- require the additional endpoint secrets during production deployment and add its D1 scheduler row migration

## Verification
- Worker TypeScript check passed
- Worker tests: 50 passed
- Main package tests: 278 passed, 1 skipped
- Portable package verification passed
- npm pack dry run passed
- Wrangler deployment dry run passed
- Local D1 migrations produced scheduler slots 0 through 5
- Real text and image requests against the additional endpoint returned HTTP 200
- Local Worker end-to-end vision request through the new slot returned HTTP 200 in 5.4 seconds
- Grounding on the 1200x675 regression image returned the expected XYXY-oriented left-title box in 9.7 seconds

## E2E / UI coverage
This is a Worker routing change with no meaningful browser UI path. The substitute verification exercised the public OpenAI-compatible request shape through a local Worker using the real additional upstream, including a base64 image and the branded public API key.
