### PR TITLE
feat(settings): raise default vision timeout to 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 - **Install and use with zero Python setup.** When no system Python 3.11+ is available, the plugin downloads a pinned, sha256-verified standalone Python 3.13 build (about 35 MB) on first use and prepares its isolated runtime with it, so new users no longer need to install Python first. A system Python or an explicit `runtime.python` override still takes precedence, and a committed manifest plus `scripts/python-bootstrap.mjs` keeps the pinned build auditable and updatable.
 
+### Changed
+
+- Raised the default vision operation timeout from 15 seconds to 30 seconds for both semaphore queueing and tool execution.
+
 ## [0.1.28] - 2026-08-17
 
 ### Fixed

--- a/lib/client.js
+++ b/lib/client.js
@@ -773,7 +773,7 @@ function draftOf(value) {
         anthropicThinking: value.provider?.anthropicThinking ?? 'omit',
         userAgent: value.provider?.userAgent ?? DEFAULT_USER_AGENT,
         language: value.language ?? 'zh',
-        timeoutMs: String(value.timeoutMs ?? 15000),
+        timeoutMs: String(value.timeoutMs ?? 30000),
         maxImageBytes: String(value.maxImageBytes ?? 4194304),
         maxImagePixels: String(value.maxImagePixels ?? 20000000),
         concurrency: String(value.concurrency ?? 4),

--- a/lib/config.js
+++ b/lib/config.js
@@ -39,7 +39,7 @@ export const Config = z.object({
         userAgent: z.string().default(DEFAULT_VISION_USER_AGENT),
     }),
     language: z.union(['zh', 'en']).default('zh'),
-    timeoutMs: z.number().default(15000),
+    timeoutMs: z.number().default(30000),
     maxImageBytes: z.number().default(4194304),
     maxImagePixels: z.number().default(20000000),
     concurrency: z.number().default(4),
@@ -101,7 +101,7 @@ export function resolveConfig(config = {}) {
     if (language !== 'zh' && language !== 'en') {
         throw new VisionToolkitError('config', 'language must be "zh" or "en"');
     }
-    const timeoutMs = config.timeoutMs ?? 15000;
+    const timeoutMs = config.timeoutMs ?? 30000;
     if (!Number.isInteger(timeoutMs) || timeoutMs < 1000 || timeoutMs > MAX_TIMEOUT_MS) {
         throw new VisionToolkitError('config', `timeoutMs must be an integer between 1000 and ${MAX_TIMEOUT_MS}`);
     }

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1077,7 +1077,7 @@ function draftOf(value: SettingsValue): Draft {
     anthropicThinking: value.provider?.anthropicThinking ?? 'omit',
     userAgent: value.provider?.userAgent ?? DEFAULT_USER_AGENT,
     language: value.language ?? 'zh',
-    timeoutMs: String(value.timeoutMs ?? 15000),
+    timeoutMs: String(value.timeoutMs ?? 30000),
     maxImageBytes: String(value.maxImageBytes ?? 4194304),
     maxImagePixels: String(value.maxImagePixels ?? 20000000),
     concurrency: String(value.concurrency ?? 4),

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,7 +114,7 @@ export const Config: Schema<VisionToolkitConfig> = z.object({
     userAgent: z.string().default(DEFAULT_VISION_USER_AGENT),
   }),
   language: z.union(['zh', 'en'] as const).default('zh'),
-  timeoutMs: z.number().default(15000),
+  timeoutMs: z.number().default(30000),
   maxImageBytes: z.number().default(4194304),
   maxImagePixels: z.number().default(20000000),
   concurrency: z.number().default(4),
@@ -209,7 +209,7 @@ export function resolveConfig(config: VisionToolkitConfig = {}): ResolvedVisionT
   if (language !== 'zh' && language !== 'en') {
     throw new VisionToolkitError('config', 'language must be "zh" or "en"')
   }
-  const timeoutMs = config.timeoutMs ?? 15000
+  const timeoutMs = config.timeoutMs ?? 30000
   if (!Number.isInteger(timeoutMs) || timeoutMs < 1000 || timeoutMs > MAX_TIMEOUT_MS) {
     throw new VisionToolkitError('config', `timeoutMs must be an integer between 1000 and ${MAX_TIMEOUT_MS}`)
   }

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -20,7 +20,7 @@ describe('resolveConfig', () => {
     expect(config.provider.anthropicThinking).toBe('omit')
     expect(config.provider.userAgent).toBe(DEFAULT_VISION_USER_AGENT)
     expect(config.language).toBe('zh')
-    expect(config.timeoutMs).toBe(15000)
+    expect(config.timeoutMs).toBe(30000)
     expect(config.maxImageBytes).toBe(4194304)
     expect(config.maxImagePixels).toBe(20000000)
     expect(isBuiltInFreeVisionProvider(config.provider)).toBe(true)


### PR DESCRIPTION
## Summary

- Raise the default vision operation timeout (`timeoutMs`) from 15000 to 30000 ms, giving both semaphore queueing and tool execution a separate 30-second budget.
- Update the Settings panel default display to 30000; the configurable range stays 1000–600000 ms.
- Regenerate `lib/config.js` and `lib/client.js` so the shipped bundle matches the source.

## Verification

- `CI=true pnpm build`: passed
- `vitest run`: 305 passed / 1 skipped
- `git diff --check`: clean
