### PR TITLE
chore: release v0.1.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 ## [Unreleased]
 
+## [0.1.30] - 2026-08-17
+
 ### Changed
 
 - Raised the default vision operation timeout from 15 seconds to 30 seconds for both semaphore queueing and tool execution.
@@ -330,7 +332,8 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 - Runtime teardown cancels in-flight operations before removing Agent-scoped tools, the activation bootstrap, and the Skill.
 - The Web client is published through the current nested `dsh.client` manifest and loader-compatible built artifact required by DSH snapshot0810.
 
-[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.29...HEAD
+[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.30...HEAD
+[0.1.30]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.29...v0.1.30
 [0.1.29]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.28...v0.1.29
 [0.1.28]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.26...v0.1.27

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anionex/dsh-vision-toolkit",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "DeepSeek Harness-native integration for agent-vision-toolkit: image Q&A, OCR, grounding, UI restoration, pixel diff, Artifacts, and Web UI.",
   "keywords": [
     "deepseek",


### PR DESCRIPTION
## Summary
- bump @anionex/dsh-vision-toolkit from 0.1.29 to 0.1.30
- Changed: default vision operation timeout raised from 15s to 30s for both semaphore queueing and tool execution
- Changed: practical global ceiling on the built-in free vision service removed (5,000 → 1,000,000,000 requests per UTC day); per-client daily and burst quotas unchanged

## Verification
- CI=true pnpm build: passed (release commit touches only package.json + CHANGELOG.md; lib artifacts unchanged)
- CI=true pnpm run verify:portable: passed (31 required files, 30 JavaScript files, 32 images)
- CI=true node_modules/.bin/vitest run: 307 passed / 1 skipped (profile E2E skipped locally with dsh 0.0.1-rc.2; CI runs it)
- git diff --check: clean