### PR TITLE
chore: release v0.1.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 ## [Unreleased]
 
+## [0.1.32] - 2026-08-18
+
 ### Fixed
 
 - Fixed the compressed-image cache silently missing on Windows when cache file paths exceeded the 260-character `MAX_PATH` limit; cache keys now use shorter 64-bit digests and are versioned as `v2`, so old oversized entries are pruned automatically.
 - Made the portable package verification and the test suite Windows-compatible, including `npm.cmd` invocation, path-separator handling, Python bootstrap fixture layout, a profile E2E prompt that avoids newline-carrying argv, and restart-helper test skips where automatic restart is intentionally unavailable.
 - Routed Windows `pnpm` batch shims through `cmd.exe` so plugin updates work when the harness resolves `pnpm` to a `pnpm.CMD` path.
 - Added a Windows CI job that runs the portable-package build, tests, and verification on `windows-latest`.
+- Fixed an intermittent `NO_ADAPTER` failure on image-input variant routes (`vision-toolkit-<provider>`) after adapter re-registration, model switches, or hot reload: wrappers now survive transient registry gaps, are re-registered when the live registry drops them, and self-heal on a periodic sweep.
 
 ## [0.1.31] - 2026-08-18
 
@@ -345,7 +348,8 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 - Runtime teardown cancels in-flight operations before removing Agent-scoped tools, the activation bootstrap, and the Skill.
 - The Web client is published through the current nested `dsh.client` manifest and loader-compatible built artifact required by DSH snapshot0810.
 
-[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.31...HEAD
+[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.32...HEAD
+[0.1.32]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.31...v0.1.32
 [0.1.31]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.30...v0.1.31
 [0.1.30]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.29...v0.1.30
 [0.1.29]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.28...v0.1.29

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anionex/dsh-vision-toolkit",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "DeepSeek Harness-native integration for agent-vision-toolkit: image Q&A, OCR, grounding, UI restoration, pixel diff, Artifacts, and Web UI.",
   "keywords": [
     "deepseek",


### PR DESCRIPTION
## Summary
- bump @anionex/dsh-vision-toolkit from 0.1.31 to 0.1.32
- Windows portability fixes (compressed-image cache MAX_PATH, portable verification, pnpm batch shims, CI job)
- Fix intermittent `NO_ADAPTER` on image-input variant routes after adapter re-registration / hot reload (#102)

## Verification
- `CI=true pnpm build` — passed
- `npm run verify:portable` — passed (31 required files, 30 JavaScript files, 32 images)
- `node_modules/.bin/vitest run tests` — 314 passed / 1 skipped
- `npm pack --dry-run` — passed (0.1.32)
- `git diff --check` — clean
