### PR TITLE
feat(skill): treat floating fast-restore control as a speed signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 ## [Unreleased]
 
+### Changed
+
+- Made the fast restore mode trigger more sensitive: a floating "快速还原为 HTML" / "快速生成" / "quick restore" control visible in the reference image now counts as a speed signal.
+
 ## [0.1.34] - 2026-08-19
 
 ### Changed

--- a/assets/skill/UPSTREAM.json
+++ b/assets/skill/UPSTREAM.json
@@ -3,7 +3,7 @@
   "repository": "https://github.com/Anionex/agent-vision-toolkit",
   "commit": "77c24ad5b5d7a123119862893129f939307f1d3f",
   "patch": "patches/vision-tools-dsh.patch",
-  "patchSha256": "ebbd49035945f094be9a582c5095d3e1689879d2501a7c82d0ca4517e38abf1b",
+  "patchSha256": "29f596fc36b476ecfe9b138ec4778f10c81fcfb550beb340cb3fc472f8cdb05f",
   "sourceFiles": [
     {
       "path": "SKILL.md",
@@ -64,8 +64,8 @@
     },
     {
       "path": "references/restore-ui.md",
-      "bytes": 10197,
-      "sha256": "8cd479a195c526098733ac518cb9928ffdafdbb3ad93e08864efe4fd7bd312b3"
+      "bytes": 10341,
+      "sha256": "447068bbc967497f02a409b091267afd1277980bfd50b859131976b7a09e1d81"
     }
   ]
 }

--- a/assets/skill/references/restore-ui.md
+++ b/assets/skill/references/restore-ui.md
@@ -10,9 +10,11 @@ structured diagram, read `restore-structure.md`.
 ## Choose the restore mode
 
 - Use **fast restore mode** when the user asks for a quick, rough,
-  approximate, prototype, or first-pass reconstruction, or explicitly values
-  speed over fidelity. Its target is a recognizable screenshot in about three
-  minutes when the project already runs.
+  approximate, prototype, or first-pass reconstruction, explicitly values
+  speed over fidelity, or the reference image itself shows a floating
+  speed-intent control such as "快速还原为 HTML" / "快速生成" / "quick
+  restore" overlay. Its target is a recognizable screenshot in about
+  three minutes when the project already runs.
 - Use the **standard restore workflow** below when the user asks for close,
   precise, pixel-level, or production-ready alignment, or does not opt into a
   faster approximation.

--- a/patches/vision-tools-dsh.patch
+++ b/patches/vision-tools-dsh.patch
@@ -803,10 +803,33 @@ index 3261fcf..68025be 100644
     nodes, labels, groups, edges, directions, and edge labels.
  6. Generate the Mermaid, Graphviz, or requested structure from that inventory.
 diff --git a/references/restore-ui.md b/references/restore-ui.md
-index f9ec11a..69627895161fc1b57c6241665255fdf86ae1c1e5 100644
+index f9ec11a..bfc63c0e4eacbd3a5eaf9453ec542d3b5380875a 100644
 --- a/references/restore-ui.md
 +++ b/references/restore-ui.md
-@@ -28,17 +28,18 @@
+@@ -10,11 +10,13 @@
+ ## Choose the restore mode
+-
+-- Use **fast restore mode** when the user asks for a quick, rough,
+-  approximate, prototype, or first-pass reconstruction, or explicitly values
+-  speed over fidelity. Its target is a recognizable screenshot in about three
+-  minutes when the project already runs.
+-- Use the **standard restore workflow** below when the user asks for close,
+-  precise, pixel-level, or production-ready alignment, or does not opt into a
+-  faster approximation.
+-
++
++- Use **fast restore mode** when the user asks for a quick, rough,
++  approximate, prototype, or first-pass reconstruction, explicitly values
++  speed over fidelity, or the reference image itself shows a floating
++  speed-intent control such as "快速还原为 HTML" / "快速生成" / "quick
++  restore" overlay. Its target is a recognizable screenshot in about
++  three minutes when the project already runs.
++- Use the **standard restore workflow** below when the user asks for close,
++  precise, pixel-level, or production-ready alignment, or does not opt into a
++  faster approximation.
++
+ ## Fast restore mode: first screenshot in about three minutes
+@@ -28,17 +30,18 @@
  1. Inspect the existing frontend stack, component library, icon set, source
     assets, and design tokens before writing code, but stop searching as soon as
     a usable local primitive is found.
@@ -833,7 +856,7 @@ index f9ec11a..69627895161fc1b57c6241665255fdf86ae1c1e5 100644
  
  ### Build the approximation
  
-@@ -47,8 +48,9 @@
+@@ -47,8 +50,9 @@
     when zoomed in.
  2. Reuse the project's existing components and CSS tokens. If its frontend or
     icon library contains a reasonably similar component or icon, use it
@@ -845,7 +868,7 @@ index f9ec11a..69627895161fc1b57c6241665255fdf86ae1c1e5 100644
  3. Use nearby existing palette tokens or visually similar CSS values. Exact
     sampled hex values, gradients, subtle borders, and shadow opacity are out of
     scope unless one of them defines the whole composition.
-@@ -57,7 +59,7 @@
+@@ -57,7 +61,7 @@
  
  ### Render once, fix once, deliver
  
@@ -854,7 +877,7 @@ index f9ec11a..69627895161fc1b57c6241665255fdf86ae1c1e5 100644
     existing browser setup.
  2. Inspect the screenshot once. If there is an obvious structural failure such
     as a missing major region, broken wrapping, or a wildly wrong scale, make
-@@ -66,7 +68,7 @@
+@@ -66,7 +70,7 @@
     small color, icon, font, shadow, radius, or spacing differences.
  
  A practical time box is roughly 30 seconds for project inspection plus
@@ -863,7 +886,7 @@ index f9ec11a..69627895161fc1b57c6241665255fdf86ae1c1e5 100644
  rendering, one correction, and screenshot delivery. Dependency installation or
  a project that does not already run may extend that target; do not compensate
  by silently switching back to a long precision loop.
-@@ -112,18 +114,19 @@
+@@ -112,18 +116,19 @@
  ### 2. Establish the coordinate system
  
  Record the reference image dimensions and the target viewport. Screenshots may
@@ -891,7 +914,7 @@ index f9ec11a..69627895161fc1b57c6241665255fdf86ae1c1e5 100644
  
  Treat model boxes as approximate handles. Use them to organize the page, but
  do not mistake their final few pixels for measured boundaries.
-@@ -141,15 +144,11 @@
+@@ -141,15 +146,11 @@
  extraction, tighten the final region to the visual's own ink; adjacent text or
  rules inside the region can become foreground components too.
  
@@ -912,7 +935,7 @@ index f9ec11a..69627895161fc1b57c6241665255fdf86ae1c1e5 100644
  ```
  
  Inspect the transparent result before use. Confirm that the whole visual is
-@@ -162,8 +161,8 @@
+@@ -162,8 +163,8 @@
  - Follow the project's existing framework and component patterns.
  - Build content, interaction, responsive layout, borders, shadows, and simple
    shapes natively.
@@ -923,7 +946,7 @@ index f9ec11a..69627895161fc1b57c6241665255fdf86ae1c1e5 100644
  - Place extracted assets with explicit logical dimensions. Preserve their
    aspect ratio and avoid baking surrounding whitespace into the asset.
  - Match structure and proportions before tuning small spacing.
-@@ -172,10 +171,10 @@
+@@ -172,10 +173,10 @@
  
  For an existing implementation, start here.
  
@@ -936,7 +959,7 @@ index f9ec11a..69627895161fc1b57c6241665255fdf86ae1c1e5 100644
     spot or explain.
  3. Fix material discrepancies: missing or wrong content, incorrect hierarchy,
     broken wrapping, visibly wrong alignment or scale, wrong component state,
-@@ -185,7 +184,7 @@
+@@ -185,7 +186,7 @@
     rasterization, antialiasing, subpixel placement, or another imperceptible
     rendering detail.
  

--- a/tests/skill.spec.ts
+++ b/tests/skill.spec.ts
@@ -69,4 +69,12 @@ describe('adapted upstream vision-tools Skill renamed to vision-skills', () => {
     expect(restoreUi).toContain('Never hand-write SVG in fast')
     expect(restoreUi).not.toMatch(/Prefer an approximate library\s+icon over cropping, tracing, or hand-drawing a new one/u)
   })
+
+  it('treats a floating fast-restore control in the reference image as a speed signal', async () => {
+    const restoreUi = await readFile(join(VISION_SKILLS_RESOURCE_BASE, 'references', 'restore-ui.md'), 'utf8')
+    expect(restoreUi).toContain('快速还原为 HTML')
+    expect(restoreUi).toContain('floating')
+    expect(restoreUi).toContain('speed over fidelity')
+    expect(restoreUi).not.toContain('一键生成')
+  })
 })


### PR DESCRIPTION
## Problem

Fast restore mode was not triggering reliably. In a recent run, the user asked to quickly restore a screenshot and the reference image contained a floating button labelled "快速还原为 HTML", but the model still fell back to the standard precision workflow.

## Change

Make the existing fast-restore trigger more sensitive with a minimal playbook change:

- `assets/skill/references/restore-ui.md` now treats a floating speed-intent control visible in the reference image (e.g. "快速还原为 HTML" / "快速生成" / "quick restore" overlay) as a fast-mode signal, alongside the existing quick/rough/approximate wording and explicit speed preference. The standard restore workflow's triggers are unchanged.
- `patches/vision-tools-dsh.patch` and `assets/skill/UPSTREAM.json` were regenerated through the upstream skill sync flow.
- Added a small regression test asserting the new signal is present in the packaged playbook.
- Added a `CHANGELOG.md` entry.

Files changed:

- `assets/skill/references/restore-ui.md`
- `patches/vision-tools-dsh.patch`
- `assets/skill/UPSTREAM.json`
- `tests/skill.spec.ts`
- `CHANGELOG.md`

## Verification

- `CI=true pnpm build` — passed
- `node_modules/.bin/vitest run` — 329 passed, 1 skipped
- `CI=true pnpm verify:portable` — passed (includes skill-sync verification and `npm pack --dry-run`)
- `node scripts/sync-skill.mjs /Users/davidyang/agent-vision-toolkit` + `node scripts/verify-skill.mjs` — clean reproduction of `assets/skill` from the patch
- `git diff --check` — clean

Browser real-user verification: not applicable — this PR only changes model-facing Skill instructions (no UI/runtime path). The substitute verification is the unit test on the packaged Skill content plus the upstream skill-sync/verify pipeline.
