### PR TITLE
chore: release v0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 ## [Unreleased]
 
+## [0.1.36] - 2026-08-20
+
 ### Added
 
 - The bundled standalone Python now downloads from the domestic mirror (Tencent Cloud COS, `dsh-vision-python-bootstrap-1317715800.cos.ap-guangzhou.myqcloud.com`) first and falls back to the GitHub release when the mirror is unreachable, so users in China no longer need GitHub connectivity for the first-run Python bootstrap. The pinned `assets/python-bootstrap.json` gained an optional `mirrorBaseUrl`, and all eight platform archives are hosted on the mirror. The locked runtime dependencies (Pillow, NumPy, vtracer) are installed from the Tencent Cloud PyPI mirror (`mirrors.cloud.tencent.com/pypi/simple`) first and fall back to the official PyPI index.
@@ -381,7 +383,8 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 - Runtime teardown cancels in-flight operations before removing Agent-scoped tools, the activation bootstrap, and the Skill.
 - The Web client is published through the current nested `dsh.client` manifest and loader-compatible built artifact required by DSH snapshot0810.
 
-[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.35...HEAD
+[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.36...HEAD
+[0.1.36]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.35...v0.1.36
 [0.1.35]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.34...v0.1.35
 [0.1.34]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.33...v0.1.34
 [0.1.33]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.32...v0.1.33

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anionex/dsh-vision-toolkit",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "DeepSeek Harness-native integration for agent-vision-toolkit: image Q&A, OCR, grounding, UI restoration, pixel diff, Artifacts, and Web UI.",
   "keywords": [
     "deepseek",


### PR DESCRIPTION
## Summary
- bump @anionex/dsh-vision-toolkit from 0.1.35 to 0.1.36
- 本次用户可见改动：托管 Python 与锁定依赖默认走国内镜像（腾讯云 COS / 腾讯云 PyPI），GitHub 与官方 PyPI 仅作兜底

## Verification
- pnpm build / verify:portable / vitest: 330 passed / 1 skipped / git diff --check 均通过
