### PR TITLE
chore: release v0.1.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 ## [Unreleased]
 
+## [0.1.38] - 2026-08-20
+
+### Fixed
+
+- Persisted the final model-visible image evidence across DSH Profile restarts, so historical images no longer consume vision quota again or change the main model's cached conversation prefix.
+- Preserved both successful descriptions and `[vision unavailable: ...]` results byte-for-byte; only requests that fail before producing any model-visible result are retried.
+- Bound persisted evidence to the Session lifecycle, attachment, focus prompt, credential, and output-affecting runtime settings to prevent replay across incompatible configurations.
+
 ## [0.1.37] - 2026-08-20
 
 ### Added
@@ -394,7 +402,8 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 - Runtime teardown cancels in-flight operations before removing Agent-scoped tools, the activation bootstrap, and the Skill.
 - The Web client is published through the current nested `dsh.client` manifest and loader-compatible built artifact required by DSH snapshot0810.
 
-[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.37...HEAD
+[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.38...HEAD
+[0.1.38]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.37...v0.1.38
 [0.1.37]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.36...v0.1.37
 [0.1.36]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.35...v0.1.36
 [0.1.35]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.34...v0.1.35

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anionex/dsh-vision-toolkit",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "DeepSeek Harness-native integration for agent-vision-toolkit: image Q&A, OCR, grounding, UI restoration, pixel diff, Artifacts, and Web UI.",
   "keywords": [
     "deepseek",


### PR DESCRIPTION
## Summary

- bump `@anionex/dsh-vision-toolkit` from 0.1.37 to 0.1.38
- persist final model-visible image evidence across DSH Profile restarts
- preserve both successful descriptions and `[vision unavailable: ...]` results byte-for-byte
- prevent incompatible replay by binding evidence to Session, attachment, prompt, credential, and output-affecting runtime settings

## Verification

- `CI=true pnpm run build`
- `npm run verify:portable` — 31 required files, 32 JavaScript files, 41 images
- `CI=true pnpm test` — 346 passed / 1 skipped
- `npm pack --dry-run` — 216 files, 7.9 MB
- `git diff --check`

## Release scope

The release commit changes only `package.json` and `CHANGELOG.md`; runtime and generated `lib/` artifacts were already merged in PR #115.