### PR TITLE
fix(worker): bound upstream inference with a fetch timeout

### DIFF
--- a/workers/moondream-openai-proxy/src/groq.ts
+++ b/workers/moondream-openai-proxy/src/groq.ts
@@ -6,6 +6,8 @@ const KEY_LEASE_MS = 120_000
 const AUTH_COOLDOWN_MS = 15 * 60 * 1000
 const RATE_LIMIT_COOLDOWN_MS = 60_000
 const TRANSIENT_COOLDOWN_MS = 5_000
+/** Must stay below KEY_LEASE_MS so a timed-out request releases before the reaper can re-lease it. */
+const DEFAULT_UPSTREAM_TIMEOUT_MS = 60_000
 
 interface ProviderSecrets {
   GROQ_API_KEY_1?: string
@@ -16,9 +18,22 @@ interface ProviderSecrets {
   FALLBACK_VISION_API_KEY?: string
   FALLBACK_VISION_MODEL?: string
   FALLBACK_VISION_URL?: string
+  UPSTREAM_TIMEOUT_MS?: string
 }
 
 type ProviderEnv = Env & ProviderSecrets
+
+function upstreamTimeoutMs(env: ProviderEnv): number {
+  const raw = Number(env.UPSTREAM_TIMEOUT_MS)
+  if (Number.isFinite(raw) && raw > 0) return Math.min(raw, KEY_LEASE_MS - 1_000)
+  return DEFAULT_UPSTREAM_TIMEOUT_MS
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === 'AbortError' || error.name === 'TimeoutError'
+    : error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')
+}
 
 export class VisionProviderError extends Error {
   constructor(
@@ -246,6 +261,8 @@ export async function runVisionCompletion(
   const statuses: number[] = []
   let lastRetryAfter: string | undefined
   let poolUnavailable = false
+  let anyAborted = false
+  const timeoutMs = upstreamTimeoutMs(env)
 
   for (let attempt = 0; attempt < upstreams.length; attempt += 1) {
     const lease = await scheduler.acquire(slots)
@@ -272,11 +289,17 @@ export async function runVisionCompletion(
           'content-type': 'application/json',
         },
         method: 'POST',
+        signal: AbortSignal.timeout(timeoutMs),
       })
-    } catch {
+    } catch (error) {
+      if (isAbortError(error)) anyAborted = true
       await releaseLease(scheduler, lease.slot, requestId, TRANSIENT_COOLDOWN_MS)
       if (attempt + 1 < upstreams.length) continue
-      throw new VisionProviderError('Vision provider is temporarily unavailable', 502, 'upstream_error')
+      throw new VisionProviderError(
+        anyAborted ? 'Vision provider timed out' : 'Vision provider is temporarily unavailable',
+        502,
+        anyAborted ? 'upstream_timeout' : 'upstream_error',
+      )
     }
 
     if (response.ok) {

--- a/workers/moondream-openai-proxy/tests/worker.spec.ts
+++ b/workers/moondream-openai-proxy/tests/worker.spec.ts
@@ -56,8 +56,12 @@ class FakeStatement {
           : Math.min(minimum, state.cooldownUntil), null)
       return { cooldown_until: next } as T
     }
+    // consumeCounter binds (?1=day, ?2=key, ?3=now, ?4=limit)
     const key = String(this.values[1])
-    const count = (this.database.counts.get(key) ?? 0) + 1
+    const limit = Number(this.values[3])
+    const current = this.database.counts.get(key) ?? 0
+    if (current >= limit) return null
+    const count = current + 1
     this.database.counts.set(key, count)
     return { request_count: count } as T
   }
@@ -173,6 +177,7 @@ function environment(database: FakeD1, burstSuccess = true): Env {
     MAX_IMAGE_PIXELS: '20000000',
     MAX_OUTPUT_TOKENS: '4096',
     MAX_REQUEST_BYTES: '33554432',
+    UPSTREAM_TIMEOUT_MS: '60000',
     LEGACY_PUBLIC_API_KEY: 'free',
     PUBLIC_API_KEY: publicApiKey,
     GROQ_API_KEY_1: 'test-groq-key-1',
@@ -602,5 +607,82 @@ describe('Worker request accounting', () => {
     )
     expect(response.status).toBe(400)
     expect(database.counts.size).toBe(0)
+  })
+
+  it('aborts and releases the lease when an upstream request exceeds the timeout', async () => {
+    const database = new FakeD1()
+    const env = environment(database) as Env & Record<string, string>
+    env.UPSTREAM_TIMEOUT_MS = '50'
+    // Faithfully simulate fetch honoring AbortSignal: reject when aborted, never resolve otherwise.
+    const groqFetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const error = new DOMException('The operation was aborted.', 'AbortError')
+          reject(error)
+        })
+      }))
+    vi.stubGlobal('fetch', groqFetch)
+
+    const response = await worker.fetch(qwenRequest(), env)
+
+    expect(response.status).toBe(502)
+    // A hung connection to one account must fail over to the other Groq accounts.
+    expect(groqFetch).toHaveBeenCalledTimes(5)
+    for (const call of groqFetch.mock.calls) {
+      expect(call[1]?.signal).toBeInstanceOf(AbortSignal)
+    }
+    // Leases are released (with the transient cooldown) rather than held until expiry.
+    expect([...database.keyStates.values()].map(state => state.activeRequests)).toEqual([0, 0, 0, 0, 0, 0])
+    for (const state of database.keyStates.values()) {
+      if (state.keySlot < 5) expect(state.cooldownUntil).toBeGreaterThan(Date.now())
+    }
+  })
+
+  it('rolls back the client quota reservation when the global daily limit is reached', async () => {
+    const database = new FakeD1()
+    const env = environment(database) as Env & Record<string, string>
+    env.GLOBAL_DAILY_LIMIT = '1'
+    vi.stubGlobal('fetch', vi.fn(async () => Response.json({
+      choices: [{ finish_reason: 'stop', message: { content: 'ok', role: 'assistant' } }],
+    })))
+
+    const first = await worker.fetch(qwenRequest(), env)
+    expect(first.status).toBe(200)
+
+    const second = await worker.fetch(qwenRequest(), env)
+    expect(second.status).toBe(429)
+    expect(await second.json()).toMatchObject({ error: { code: 'global_daily_limit_exceeded' } })
+
+    // The rejected request must not leave the client charged; the global row stays at its cap.
+    const entries = [...database.counts.entries()]
+    const clientEntry = entries.find(([key]) => key !== '__global__')
+    expect(clientEntry?.[1]).toBe(1)
+    expect(database.counts.get('__global__')).toBe(1)
+  })
+
+  it('decrements (not deletes) quota rows above one when rolling back concurrent usage', async () => {
+    const database = new FakeD1()
+    const secret = '0123456789abcdef0123456789abcdef'
+    const key = await crypto.subtle.importKey(
+      'raw',
+      new TextEncoder().encode(secret),
+      { hash: 'SHA-256', name: 'HMAC' },
+      false,
+      ['sign'],
+    )
+    const digest = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode('203.0.113.10'))
+    const clientHash = Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, '0')).join('')
+    // Simulate prior traffic so the decrement branch (request_count > 1) is exercised, not DELETE.
+    database.counts.set(clientHash, 2)
+    database.counts.set('__global__', 2)
+
+    const response = await worker.fetch(
+      request('data:image/png;base64,iVBORw0KGgo='),
+      environment(database),
+    )
+
+    expect(response.status).toBe(400)
+    expect(database.counts.get(clientHash)).toBe(2)
+    expect(database.counts.get('__global__')).toBe(2)
   })
 })

--- a/workers/moondream-openai-proxy/worker-configuration.d.ts
+++ b/workers/moondream-openai-proxy/worker-configuration.d.ts
@@ -12,6 +12,7 @@ interface __BaseEnv_Env {
 	MAX_IMAGE_PIXELS: "20000000";
 	MAX_OUTPUT_TOKENS: "4096";
 	MAX_REQUEST_BYTES: "33554432";
+	UPSTREAM_TIMEOUT_MS: "60000";
 	IP_HASH_SECRET: string;
 }
 declare namespace Cloudflare {

--- a/workers/moondream-openai-proxy/wrangler.jsonc
+++ b/workers/moondream-openai-proxy/wrangler.jsonc
@@ -38,7 +38,8 @@
     "MAX_IMAGE_BYTES": "4194304",
     "MAX_IMAGE_PIXELS": "20000000",
     "MAX_OUTPUT_TOKENS": "4096",
-    "MAX_REQUEST_BYTES": "33554432"
+    "MAX_REQUEST_BYTES": "33554432",
+    "UPSTREAM_TIMEOUT_MS": "60000"
   },
   "observability": {
     "enabled": true,


### PR DESCRIPTION
A hung Groq/Gemini connection had no AbortSignal on its fetch, so it held a scheduler slot until the Worker was killed and then for the full KEY_LEASE_MS (120s) afterward. With only five Groq slots, five hung requests could take the pool out of rotation for up to two minutes, returning 429s to every caller. Remote image fetches already used a 10s timeout; the inference call did not.

- Pass AbortSignal.timeout() to the upstream chat-completions fetch. Default 60s, tunable via UPSTREAM_TIMEOUT_MS, clamped to stay below KEY_LEASE_MS so a timed-out request releases its slot before the reaper can re-lease it to another caller.
- On abort/timeout, release the lease with the transient cooldown and fail over to the next upstream instead of holding the slot. When all upstreams time out, return 502 with code "upstream_timeout" (distinct from the generic "upstream_error").
- Add UPSTREAM_TIMEOUT_MS to wrangler.jsonc vars and the generated Env type so the knob is documented and type-checked.

Also harden quota-rollback coverage around the recent scheduling work:

- The FakeD1 test double ignored the "WHERE request_count < ?" clause in consumeCounter and always incremented, so the global-capacity rollback branch could never be exercised. It now returns null at the limit, matching real D1 behavior.
- Test that a request rejected at GLOBAL_DAILY_LIMIT rolls back the client counter (no double charge) while the global row stays capped.
- Test that rolling back when request_count > 1 takes the decrement branch (UPDATE ... SET count - 1) and does not DELETE the row shared with concurrent consumers.
- Test that a hung upstream is aborted within the timeout, fails over across all five Groq accounts, sends an AbortSignal on every attempt, and leaves every lease released with the transient cooldown set.

Verified: tsc -p tsconfig.json clean; vitest 5 files / 56 tests pass (was 53).

## Problem

<!-- What concrete user, integration, or maintenance problem does this change solve? -->

## Change

<!-- Summarize the implementation and the affected tools, lifecycle paths, files, or public claims. -->

## Verification

<!-- List the exact commands and results. Include focused tests plus the strongest practical assembled-profile or visual evidence. -->

- [ ] `npm run verify:portable`
- [ ] Focused tests for the changed behavior
- [ ] `pnpm run build` and `pnpm test` when source/runtime/client behavior changed
- [ ] Clean Web/Headless, Artifact, Settings, or UI-restoration evidence when the affected surface requires it
- [ ] `git diff --check`

## Product and security checklist

- [ ] I preserved independent tool schemas and Agent-scoped progressive exposure.
- [ ] I kept health/version administration out of model tool schemas.
- [ ] I did not expose credentials, image base64, authorization headers, private data, or unbounded upstream output.
- [ ] I updated README/JSDoc/troubleshooting/traceability and `CHANGELOG.md` for user-visible changes.
- [ ] I kept `README.md` and `README.zh.md` synchronized.
- [ ] I used repository-owned, sanitized visual evidence for visible changes.
- [ ] Upstream algorithm changes, if any, came through the documented sync and manifest process.

## Screenshots or artifacts

<!-- Add only evidence that materially verifies visual or Web behavior. Remove this section when it is not applicable. -->
