### PR TITLE
fix(worker): scope key-lease release to a reaper generation

### DIFF
--- a/workers/moondream-openai-proxy/migrations/0004_add_reap_generation.sql
+++ b/workers/moondream-openai-proxy/migrations/0004_add_reap_generation.sql
@@ -1,0 +1,4 @@
+-- Bumps whenever the reaper zeroes an expired lease. release() is scoped to
+-- the generation it was handed, so a request that outlives its lease cannot
+-- decrement the counter of a request that re-leased the same slot.
+ALTER TABLE groq_key_state ADD COLUMN reap_generation INTEGER NOT NULL DEFAULT 0;

--- a/workers/moondream-openai-proxy/src/groq.ts
+++ b/workers/moondream-openai-proxy/src/groq.ts
@@ -73,6 +73,8 @@ function configuredUpstreams(env: ProviderEnv, boxOrder: BoxOrder = 'yxyx'): Vis
 
 interface KeyLease {
   slot: number
+  /** Reaper generation at acquire time; stale releases are scoped to this so they cannot touch a re-leased slot. */
+  generation: number
 }
 
 /** Cross-isolate key allocator backed by the Worker's existing D1 database. */
@@ -84,7 +86,7 @@ export class VisionUpstreamScheduler {
     const now = Date.now()
     await this.database.prepare(`
       UPDATE groq_key_state
-      SET active_requests = 0, lease_expires_at = 0, updated_at = ?1
+      SET active_requests = 0, lease_expires_at = 0, reap_generation = reap_generation + 1, updated_at = ?1
       WHERE active_requests > 0 AND lease_expires_at <= ?1
     `).bind(now).run()
     const slotParameters = slots.map((_, index) => `?${index + 3}`).join(', ')
@@ -102,12 +104,12 @@ export class VisionUpstreamScheduler {
         ORDER BY active_requests ASC, last_selected_at ASC, key_slot ASC
         LIMIT 1
       )
-      RETURNING key_slot
-    `).bind(now, now + KEY_LEASE_MS, ...slots).first<{ key_slot: number }>()
-    return lease === null ? undefined : { slot: lease.key_slot }
+      RETURNING key_slot, reap_generation
+    `).bind(now, now + KEY_LEASE_MS, ...slots).first<{ key_slot: number; reap_generation: number }>()
+    return lease === null ? undefined : { generation: lease.reap_generation, slot: lease.key_slot }
   }
 
-  async release(slot: number, cooldownMs = 0): Promise<void> {
+  async release(slot: number, generation: number, cooldownMs = 0): Promise<void> {
     const now = Date.now()
     await this.database.prepare(`
       UPDATE groq_key_state
@@ -116,8 +118,8 @@ export class VisionUpstreamScheduler {
         cooldown_until = MAX(cooldown_until, ?2),
         lease_expires_at = CASE WHEN active_requests <= 1 THEN 0 ELSE lease_expires_at END,
         updated_at = ?1
-      WHERE key_slot = ?3
-    `).bind(now, now + cooldownMs, slot).run()
+      WHERE key_slot = ?3 AND reap_generation = ?4
+    `).bind(now, now + cooldownMs, slot, generation).run()
   }
 
   async retryAfterSeconds(slots: number[]): Promise<string | undefined> {
@@ -160,11 +162,12 @@ function cooldownForStatus(status: number, retryAfter: string | null): number {
 async function releaseLease(
   scheduler: VisionUpstreamScheduler,
   slot: number,
+  generation: number,
   requestId: string,
   cooldownMs = 0,
 ): Promise<void> {
   try {
-    await scheduler.release(slot, cooldownMs)
+    await scheduler.release(slot, generation, cooldownMs)
   } catch (error) {
     console.error(JSON.stringify({
       error: error instanceof Error ? error.message : String(error),
@@ -256,7 +259,7 @@ export async function runVisionCompletion(
     }
     const upstream = upstreamBySlot.get(lease.slot)
     if (upstream === undefined) {
-      await releaseLease(scheduler, lease.slot, requestId, TRANSIENT_COOLDOWN_MS)
+      await releaseLease(scheduler, lease.slot, lease.generation, requestId, TRANSIENT_COOLDOWN_MS)
       continue
     }
     let response: Response
@@ -274,13 +277,13 @@ export async function runVisionCompletion(
         method: 'POST',
       })
     } catch {
-      await releaseLease(scheduler, lease.slot, requestId, TRANSIENT_COOLDOWN_MS)
+      await releaseLease(scheduler, lease.slot, lease.generation, requestId, TRANSIENT_COOLDOWN_MS)
       if (attempt + 1 < upstreams.length) continue
       throw new VisionProviderError('Vision provider is temporarily unavailable', 502, 'upstream_error')
     }
 
     if (response.ok) {
-      await releaseLease(scheduler, lease.slot, requestId)
+      await releaseLease(scheduler, lease.slot, lease.generation, requestId)
       let payload: unknown
       try {
         payload = await response.json()
@@ -299,7 +302,7 @@ export async function runVisionCompletion(
     const cooldownMs = cooldownForStatus(response.status, retryAfter)
     lastRetryAfter = retryAfter
       ?? (response.status === 429 ? String(Math.ceil(cooldownMs / 1000)) : lastRetryAfter)
-    await releaseLease(scheduler, lease.slot, requestId, cooldownMs)
+    await releaseLease(scheduler, lease.slot, lease.generation, requestId, cooldownMs)
     console.warn(JSON.stringify({
       attempt: attempt + 1,
       cooldownMs,

--- a/workers/moondream-openai-proxy/tests/worker.spec.ts
+++ b/workers/moondream-openai-proxy/tests/worker.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import worker from '../src/index'
 import {
   GROQ_CHAT_COMPLETIONS_URL,
+  VisionUpstreamScheduler,
   __test__ as providerTest,
 } from '../src/groq'
 import { CANONICAL_MODEL, QWEN_MODEL } from '../src/protocol'
@@ -18,6 +19,7 @@ interface FakeKeyState {
   keySlot: number
   lastSelectedAt: number
   leaseExpiresAt: number
+  reapGeneration: number
 }
 
 class FakeStatement {
@@ -44,7 +46,7 @@ class FakeStatement {
       selected.activeRequests += 1
       selected.lastSelectedAt = now
       selected.leaseExpiresAt = Math.max(selected.leaseExpiresAt, leaseExpiresAt)
-      return { key_slot: selected.keySlot } as T
+      return { key_slot: selected.keySlot, reap_generation: selected.reapGeneration } as T
     }
     if (this.sql.includes('MIN(cooldown_until)')) {
       const now = Number(this.values.at(-1))
@@ -73,6 +75,7 @@ class FakeStatement {
         if (state.activeRequests > 0 && state.leaseExpiresAt <= now) {
           state.activeRequests = 0
           state.leaseExpiresAt = 0
+          state.reapGeneration += 1
         }
       }
     }
@@ -80,8 +83,10 @@ class FakeStatement {
       if (this.database.failSchedulerRelease) throw new Error('scheduler release unavailable')
       const cooldownUntil = Number(this.values[1])
       const slot = Number(this.values[2])
+      const generation = Number(this.values[3])
       const state = this.database.keyStates.get(slot)
-      if (state !== undefined) {
+      // Scoped by reap_generation: a stale release for a reaped lease affects no rows.
+      if (state !== undefined && state.reapGeneration === generation) {
         state.activeRequests = Math.max(0, state.activeRequests - 1)
         state.cooldownUntil = Math.max(state.cooldownUntil, cooldownUntil)
         if (state.activeRequests === 0) state.leaseExpiresAt = 0
@@ -109,7 +114,7 @@ class FakeD1 {
   failSchedulerRelease = false
   readonly keyStates = new Map<number, FakeKeyState>(Array.from({ length: 6 }, (_, keySlot) => [
     keySlot,
-    { activeRequests: 0, cooldownUntil: 0, keySlot, lastSelectedAt: 0, leaseExpiresAt: 0 },
+    { activeRequests: 0, cooldownUntil: 0, keySlot, lastSelectedAt: 0, leaseExpiresAt: 0, reapGeneration: 0 },
   ]))
 
   prepare(sql: string): FakeStatement {
@@ -602,5 +607,52 @@ describe('Worker request accounting', () => {
     )
     expect(response.status).toBe(400)
     expect(database.counts.size).toBe(0)
+  })
+})
+
+describe('VisionUpstreamScheduler', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('does not let a stale release corrupt a slot re-leased after its lease expired', async () => {
+    const database = new FakeD1()
+    const slot0 = database.keyStates.get(0)!
+    // Request A is mid-flight on slot 0 but has run past its lease expiry.
+    slot0.activeRequests = 1
+    slot0.leaseExpiresAt = 100
+    vi.spyOn(Date, 'now').mockReturnValue(200)
+    const scheduler = new VisionUpstreamScheduler(database)
+
+    // Request B arrives: the reaper reaps A's expired lease and B leases slot 0.
+    const leaseB = await scheduler.acquire([0])
+    expect(leaseB).toEqual({ generation: 1, slot: 0 })
+    expect(slot0.activeRequests).toBe(1)
+
+    // A finally finishes and releases its stale (generation-0) lease. It must not
+    // touch B's active count.
+    await scheduler.release(0, 0, 0)
+    expect(slot0.activeRequests).toBe(1)
+
+    // B releases with the generation it was handed; the counter returns to zero.
+    await scheduler.release(0, leaseB!.generation, 0)
+    expect(slot0.activeRequests).toBe(0)
+  })
+
+  it('keeps concurrent leases on the same slot releasing independently within one generation', async () => {
+    const database = new FakeD1()
+    vi.spyOn(Date, 'now').mockReturnValue(500)
+    const scheduler = new VisionUpstreamScheduler(database)
+
+    // Two requests land on the same slot before either lease is reaped.
+    const leaseA = await scheduler.acquire([0])
+    const leaseC = await scheduler.acquire([0])
+    expect(leaseA).toEqual({ generation: 0, slot: 0 })
+    expect(leaseC).toEqual({ generation: 0, slot: 0 })
+    expect(database.keyStates.get(0)?.activeRequests).toBe(2)
+
+    // Both releases carry the same generation and must both decrement.
+    await scheduler.release(0, leaseA!.generation, 0)
+    expect(database.keyStates.get(0)?.activeRequests).toBe(1)
+    await scheduler.release(0, leaseC!.generation, 0)
+    expect(database.keyStates.get(0)?.activeRequests).toBe(0)
   })
 })


### PR DESCRIPTION
## Problem

The stateful Groq key scheduler (`VisionUpstreamScheduler`, from #74/#77) tracks in-flight requests per slot via `active_requests` and a 120s `KEY_LEASE_MS`. Before every `acquire`, a reaper zeroes expired slots:

```sql
UPDATE groq_key_state SET active_requests = 0, lease_expires_at = 0
WHERE active_requests > 0 AND lease_expires_at <= ?
```

The reaper does not record which lease it cleared. If request **A** is still in flight past 120s and request **B**'s `acquire` reaps A's slot, B increments `active_requests` back to 1. When A finally calls `release` (`active_requests = MAX(0, count - 1) WHERE key_slot = ?`), it decrements **B's** count to 0 while B is still running. The slot looks idle while B holds it, so request **C** can double-book the same Groq key. Under sustained load or slow upstreams this corrupts the scheduler and causes avoidable 429s.

## Change

Scope every release to the reaper generation the lease was acquired under, so a request that outlives its lease cannot touch a re-leased slot.

- **Migration `0004_add_reap_generation.sql`**: adds `reap_generation INTEGER NOT NULL DEFAULT 0` to `groq_key_state`.
- Reaper increments `reap_generation` whenever it zeroes an expired lease.
- `acquire` returns `{ slot, generation }` via `RETURNING key_slot, reap_generation`.
- `release(slot, generation, cooldownMs)` adds `AND reap_generation = ?`; a stale release matches 0 rows.
- Two concurrent leases within the same generation (the common <120s case) share the generation and both decrement correctly.
- Threads `generation` through `KeyLease`, `releaseLease`, and all four call sites in `runVisionCompletion`.
- Extends `FakeD1` to model `reap_generation` like D1 (reaper increments, release is generation-scoped).

Independent of the fetch-timeout work in #121; built directly on `main`.

## Verification

- `npx tsc -p tsconfig.json` — clean
- `npx vitest run` — **5 files / 55 tests pass** (53 prior + 2 new scheduler tests)
- New test reproduces the corruption: A expires → B re-leases slot 0 → A's stale generation-0 release leaves B's `active_requests` at 1 → B's generation-1 release returns it to 0.
- New test covers the normal concurrent case: two leases in the same generation both decrement.
- `git diff --check` — clean

## Product and security checklist

- [x] Worker-internal scheduling only; no model-facing tool schema change.
- [x] Health/version administration unchanged.
- [x] No credentials, image data, or upstream responses logged/exposed; only an integer counter column.
- [x] No user-visible behavior change (internal scheduler correctness); no README/CHANGELOG needed.
- [x] No upstream algorithm/sync changes.

No screenshots — server-side correctness fix with no visual surface.