### PR TITLE
chore: release v0.1.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 ## [Unreleased]
 
+## [0.1.39] - 2026-08-25
+
+### Fixed
+
+- Retried transient Windows `EBUSY`/`EPERM`/`EACCES` failures when deleting or replacing managed and bundled-Python runtime directories, so antivirus real-time scans no longer make first-run environment preparation report "运行环境尚未就绪".
+- Kept the primary runtime preparation error visible when best-effort cleanup also fails: staging, quarantine, bundled-Python staging, and lock cleanup now log a warning instead of masking the real failure.
+
 ## [0.1.38] - 2026-08-20
 
 ### Fixed
@@ -402,7 +409,8 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 - Runtime teardown cancels in-flight operations before removing Agent-scoped tools, the activation bootstrap, and the Skill.
 - The Web client is published through the current nested `dsh.client` manifest and loader-compatible built artifact required by DSH snapshot0810.
 
-[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.38...HEAD
+[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.39...HEAD
+[0.1.39]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.38...v0.1.39
 [0.1.38]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.37...v0.1.38
 [0.1.37]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.36...v0.1.37
 [0.1.36]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.35...v0.1.36

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anionex/dsh-vision-toolkit",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "DeepSeek Harness-native integration for agent-vision-toolkit: image Q&A, OCR, grounding, UI restoration, pixel diff, Artifacts, and Web UI.",
   "keywords": [
     "deepseek",


### PR DESCRIPTION
## Summary

- bump @anionex/dsh-vision-toolkit from 0.1.38 to 0.1.39
- Windows managed/bundled-Python runtime cleanup now retries transient EBUSY/EPERM/EACCES and no longer lets cleanup failures mask the primary runtime error (fixes Anionex/agent-vision-toolkit#37)

## Verification

- `CI=true pnpm build` — passed; `lib/` unchanged
- `node_modules/.bin/vitest run` — 354 passed / 1 skipped
- `CI=true pnpm run verify:portable` — passed
- `git diff --check` — clean
