### PR TITLE
chore: release v0.1.43 with DSH 0.1.3-alpha.2 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,16 @@ jobs:
 
   portable-package:
     if: github.event.repository.visibility == 'public'
-    name: Portable package (Node ${{ matrix.node }})
+    name: Portable package (Node ${{ matrix.node }}, DSH ${{ matrix.dsh }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        node: [22.19.0, 24.x]
+        include:
+          - node: 22.19.0
+            dsh: 0.1.2-rc.1
+          - node: 24.x
+            dsh: 0.1.3-alpha.2
 
     steps:
       - name: Check out repository
@@ -81,7 +85,7 @@ jobs:
       - name: Install the compatible DSH CLI for Profile acceptance
         run: |
           npm install --global --prefix "$RUNNER_TEMP/dsh-cli" \
-            @deepseek-ai/dsh@0.1.2-rc.1 \
+            @deepseek-ai/dsh@${{ matrix.dsh }} \
             --registry=https://registry.npmjs.org
           echo "$RUNNER_TEMP/dsh-cli/bin" >> "$GITHUB_PATH"
 
@@ -94,7 +98,7 @@ jobs:
       - name: Run unit and required Profile acceptance tests
         run: pnpm test
         env:
-          DSH_VISION_PROFILE_DSH_VERSION: "0.1.2-rc.1"
+          DSH_VISION_PROFILE_DSH_VERSION: "${{ matrix.dsh }}"
           DSH_VISION_REQUIRE_PROFILE_E2E: "1"
 
       - name: Verify portable package surface
@@ -153,7 +157,7 @@ jobs:
         shell: bash
         run: |
           npm install --global --prefix "$RUNNER_TEMP/dsh-cli" \
-            @deepseek-ai/dsh@0.1.2-rc.1 \
+            @deepseek-ai/dsh@0.1.3-alpha.2 \
             --registry=https://registry.npmjs.org
           echo "$RUNNER_TEMP/dsh-cli" >> "$GITHUB_PATH"
 
@@ -166,7 +170,7 @@ jobs:
       - name: Run unit and required Profile acceptance tests
         run: pnpm test
         env:
-          DSH_VISION_PROFILE_DSH_VERSION: "0.1.2-rc.1"
+          DSH_VISION_PROFILE_DSH_VERSION: "0.1.3-alpha.2"
           DSH_VISION_REQUIRE_PROFILE_E2E: "1"
 
       - name: Verify portable package surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 ## [Unreleased]
 
+## [0.1.43] - 2026-09-08
+
+### Changed
+
+- Declared exact compatibility for the official DSH release window `0.1.2-rc.1`, `0.1.3-alpha.1`, and `0.1.3-alpha.2` under `dsh.compatibility.dshReleases`, so the DSH STORE Catalog can read a per-release verdict instead of `unknown`.
+- Verified DSH `0.1.3-alpha.2` with a clean disposable Headless Profile install, boot, visual-tool execution, and uninstall acceptance.
+- Recorded DSH `0.1.3-alpha.1` as `unknown`: the official GitHub release has no npm artifact, so there is no installable build to accept.
+
 ## [0.1.42] - 2026-09-05
 
 ### Changed
@@ -426,7 +434,8 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 - Runtime teardown cancels in-flight operations before removing Agent-scoped tools, the activation bootstrap, and the Skill.
 - The Web client is published through the current nested `dsh.client` manifest and loader-compatible built artifact required by DSH snapshot0810.
 
-[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.42...HEAD
+[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.43...HEAD
+[0.1.43]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.42...v0.1.43
 [0.1.42]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.40...v0.1.42
 [0.1.40]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.39...v0.1.40
 [0.1.39]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.38...v0.1.39

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anionex/dsh-vision-toolkit",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "DeepSeek Harness-native integration for agent-vision-toolkit: image Q&A, OCR, grounding, UI restoration, pixel diff, Artifacts, and Web UI.",
   "keywords": [
     "deepseek",
@@ -102,7 +102,9 @@
         "0.1.2-alpha.3": "compatible",
         "0.1.2-alpha.4": "compatible",
         "0.1.2-alpha.5": "compatible",
-        "0.1.2-rc.1": "compatible"
+        "0.1.2-rc.1": "compatible",
+        "0.1.3-alpha.1": "unknown",
+        "0.1.3-alpha.2": "compatible"
       },
       "profiles": [
         "web",

--- a/tests/package-layout.spec.ts
+++ b/tests/package-layout.spec.ts
@@ -63,11 +63,17 @@ describe('package layout contract', () => {
     ]))
   })
 
-  it('declares the exact DSH rc.1 and runtime compatibility contract', () => {
+  it('declares the exact DSH release window and runtime compatibility contract', () => {
     expect(PACKAGE.engines?.node).toBe('^22.19.0 || >=24.0.0')
     expect(PACKAGE.dsh?.compatibility?.dsh).toBe('>=0.1.0-rc.8 <0.2.0')
-    expect(PACKAGE.dsh?.compatibility?.dshReleases?.['0.1.2-rc.1']).toBe('compatible')
     expect(PACKAGE.dsh?.compatibility?.profiles).toEqual(['web', 'headless'])
+    // DSH STORE reads the official latest-three window per release and needs at
+    // least one exact `compatible` verdict; a range alone is not installable evidence.
+    expect(PACKAGE.dsh?.compatibility?.dshReleases?.['0.1.2-rc.1']).toBe('compatible')
+    expect(PACKAGE.dsh?.compatibility?.dshReleases?.['0.1.3-alpha.1']).toBe('unknown')
+    expect(PACKAGE.dsh?.compatibility?.dshReleases?.['0.1.3-alpha.2']).toBe('compatible')
+    const window = ['0.1.2-rc.1', '0.1.3-alpha.1', '0.1.3-alpha.2']
+    expect(window.filter(release => PACKAGE.dsh?.compatibility?.dshReleases?.[release] === 'compatible')).not.toHaveLength(0)
   })
 
   it('ships runtime, pinned upstream, adapted Skill resources, lib, src, patch, and docs in files', async () => {


### PR DESCRIPTION
## Summary

- release `@anionex/dsh-vision-toolkit` as `0.1.43`
- declare the exact official DSH release window under `dsh.compatibility.dshReleases`: `0.1.2-rc.1: compatible`, `0.1.3-alpha.1: unknown`, `0.1.3-alpha.2: compatible`
- run the required Profile acceptance against `0.1.3-alpha.2` on the Linux Node matrix and Windows, and keep `0.1.2-rc.1` coverage on Node 22.19.0
- lock the window, and the DSH STORE rule that at least one window release must be exactly `compatible`, in the package-layout contract suite

## Context

Addresses the two blockers recorded in [DSH-Store issue #170](https://github.com/AI-Scarlett/DSH-Store/issues/170):

| Blocker | Deterministic cause | Author-side fix |
|---|---|---|
| `DSH_LATEST_THREE_COMPATIBILITY_HOLD` (unlisted) | the Catalog entry pinned at `29850a83` (v0.1.7) has `unknown` for every window release | declare each window release exactly in the new fixed-Commit manifest |
| `Update deferred` | `repos/Anionex/dsh-vision-toolkit/compare/29850a83...main` returns `total_commits: 268`, above the Store's `updates.maxCommitSpan: 200` | none: the gap only grows, so the Store still needs one manual fixed-Commit repin |

`0.1.3-alpha.1` is recorded as `unknown`, not `compatible`: the official GitHub release has no npm artifact (`https://registry.npmjs.org/@deepseek-ai%2Fdsh/0.1.3-alpha.1` returns HTTP 404), so there is no installable build to accept. `0.1.2-rc.1` and `0.1.3-alpha.2` supply the exact `compatible` the window needs.

## Verification

- `CI=true pnpm run build` — `git diff --exit-code -- lib` clean
- `npm run verify:portable` — 31 required files, 33 JavaScript files, 42 images
- `DSH_VISION_PROFILE_DSH_VERSION=0.1.3-alpha.2 DSH_VISION_REQUIRE_PROFILE_E2E=1 vitest run tests` — 27 files, 404 tests passed, including the clean disposable Headless Profile install, boot, `vision_glance` tool call, and uninstall
- profile E2E against DSH `0.1.2-rc.1` — passed
- `npm pack --dry-run --json` — `anionex-dsh-vision-toolkit-0.1.43.tgz`, 222 files, 8,017,195 bytes
- Ruby Psych parse of `.github/workflows/ci.yml`
- `git diff --check`

Local note: `pnpm test` inside the DSH Desktop host injects an Electron `node` shim (ABI 148) that breaks the disposable Profile's `fs-ext` native module. CI uses the setup-node runtime and is unaffected; the identical suite passes locally through `node_modules/.bin/vitest`.
