### PR TITLE
chore: release v0.1.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 
 ## [Unreleased]
 
+## [0.1.44] - 2026-09-10
+
 ### Fixed
 
 - Kept pasted-image drafts working on DSH 0.1.5, which renamed the composer's draft snapshot field from `imageIds` to `attachmentIds`. The plugin now reads the new name and keeps the old one only as a fallback, so the post-replay probe no longer throws on an undefined list.
@@ -447,7 +449,8 @@ All notable user-facing changes to DSH Vision Toolkit are documented in this fil
 - Runtime teardown cancels in-flight operations before removing Agent-scoped tools, the activation bootstrap, and the Skill.
 - The Web client is published through the current nested `dsh.client` manifest and loader-compatible built artifact required by DSH snapshot0810.
 
-[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.43...HEAD
+[Unreleased]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.44...HEAD
+[0.1.44]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.43...v0.1.44
 [0.1.43]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.42...v0.1.43
 [0.1.42]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.40...v0.1.42
 [0.1.40]: https://github.com/Anionex/dsh-vision-toolkit/compare/v0.1.39...v0.1.40

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anionex/dsh-vision-toolkit",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "DeepSeek Harness-native integration for agent-vision-toolkit: image Q&A, OCR, grounding, UI restoration, pixel diff, Artifacts, and Web UI.",
   "keywords": [
     "deepseek",


### PR DESCRIPTION
## Summary

Release **v0.1.44**, shipping the DSH 0.1.5 adaptation that landed in #148.

This commit touches only `package.json` and `CHANGELOG.md`, as the release runbook requires; `lib/` is unchanged because the version is read from `package.json` at runtime.

## Verification

- `CI=true pnpm install --frozen-lockfile` → exit 0
- `CI=true pnpm build` → exit 0, `lib/` unchanged by the release commit
- `npm run verify:portable` → `portable verification passed: 31 required files, 33 JavaScript files, 42 images`
- `pnpm test` → **405 passed / 1 skipped**
- `git diff --check` → clean

The underlying adaptation was verified end-to-end before merge: a clean Profile install, boot, and host-route acceptance on all three releases of the official 0.1.5 window (`0.1.5-alpha.1`, `0.1.5-alpha.2`, `0.1.5-rc.1`), plus a real-browser check of the Settings page with zero console and page errors.
